### PR TITLE
feat: ES6 support (arrows, classes, destructuring, let/const, …)

### DIFF
--- a/arrow_test.go
+++ b/arrow_test.go
@@ -1,0 +1,123 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestArrowFunction(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Single identifier parameter, concise body.
+		test(`
+            var double = x => x * 2;
+            double(21);
+        `, 42)
+
+		// Empty parameter list.
+		test(`
+            var answer = () => 42;
+            answer();
+        `, 42)
+
+		// Multiple parameters.
+		test(`
+            var add = (a, b) => a + b;
+            add(3, 4);
+        `, 7)
+
+		// Parenthesised single parameter.
+		test(`
+            var inc = (a) => a + 1;
+            inc(10);
+        `, 11)
+
+		// Block body with an explicit return and local var.
+		test(`
+            var f = (a) => { var r = a + 1; return r; };
+            f(10);
+        `, 11)
+
+		// A block body with no return yields undefined.
+		test(`
+            var f = () => { 1 + 1; };
+            f();
+        `, "undefined")
+
+		// typeof an arrow function is "function".
+		test(`typeof (() => 1)`, "function")
+
+		// length reflects the parameter count.
+		test(`((a, b, c) => 0).length`, 3)
+	})
+}
+
+func TestArrowFunction_higherOrder(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            [1, 2, 3].map(x => x * x).join(",");
+        `, "1,4,9")
+
+		test(`
+            [1, 2, 3, 4].filter(x => x % 2 === 0).join(",");
+        `, "2,4")
+
+		test(`
+            [1, 2, 3, 4].reduce((acc, x) => acc + x, 0);
+        `, 10)
+
+		// Currying via nested arrows.
+		test(`
+            var add = a => b => a + b;
+            add(2)(3);
+        `, 5)
+	})
+}
+
+func TestArrowFunction_lexicalThis(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// `this` inside an arrow is captured from the enclosing method,
+		// not rebound by the callback invocation.
+		test(`
+            var obj = {
+                value: 5,
+                run: function() {
+                    return [1].map(() => this.value)[0];
+                },
+            };
+            obj.run();
+        `, 5)
+
+		// Several layers deep, `this` is still the method's receiver.
+		test(`
+            var obj = {
+                values: [1, 2, 3],
+                factor: 10,
+                scaled: function() {
+                    return this.values.map(v => v * this.factor).join(",");
+                },
+            };
+            obj.scaled();
+        `, "10,20,30")
+	})
+}
+
+func TestArrowFunction_arguments(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// An arrow function does not bind its own `arguments`; it sees the
+		// enclosing function's `arguments`.
+		test(`
+            function outer() {
+                var inner = () => arguments[0];
+                return inner();
+            }
+            outer("hello");
+        `, "hello")
+	})
+}

--- a/ast/node.go
+++ b/ast/node.go
@@ -230,6 +230,7 @@ type FunctionLiteral struct {
 	Source          string
 	DeclarationList []Declaration
 	Function        file.Idx
+	IsArrow         bool
 }
 
 // Idx0 implements Node.

--- a/ast/node.go
+++ b/ast/node.go
@@ -708,6 +708,9 @@ type ForInStatement struct {
 	Source Expression
 	Body   Statement
 	For    file.Idx
+	// Lexical is token.LET or token.CONST when Into declares a block-scoped
+	// loop variable.
+	Lexical token.Token
 }
 
 // Idx0 implements Node.
@@ -730,6 +733,9 @@ type ForStatement struct {
 	Test        Expression
 	Body        Statement
 	For         file.Idx
+	// Lexical is token.LET or token.CONST when the initializer declares
+	// block-scoped loop variables, requiring a per-iteration environment.
+	Lexical token.Token
 }
 
 // Idx0 implements Node.
@@ -912,6 +918,26 @@ func (vs *VariableStatement) Idx1() file.Idx {
 
 // expression implements Statement.
 func (*VariableStatement) statement() {}
+
+// LexicalDeclaration represents a block-scoped let or const declaration.
+type LexicalDeclaration struct {
+	List  []Expression
+	Idx   file.Idx
+	Token token.Token // token.LET or token.CONST
+}
+
+// Idx0 implements Node.
+func (ld *LexicalDeclaration) Idx0() file.Idx {
+	return ld.Idx
+}
+
+// Idx1 implements Node.
+func (ld *LexicalDeclaration) Idx1() file.Idx {
+	return ld.List[len(ld.List)-1].Idx1()
+}
+
+// statement implements Statement.
+func (*LexicalDeclaration) statement() {}
 
 // WhileStatement represents a while statement.
 type WhileStatement struct {

--- a/ast/node.go
+++ b/ast/node.go
@@ -361,6 +361,9 @@ type Property struct {
 	Value Expression
 	Key   string
 	Kind  string
+	// KeyExpression holds the key of a computed property, e.g. {[expr]: v}.
+	// When non-nil it is evaluated at runtime and Key is ignored.
+	KeyExpression Expression
 }
 
 // RegExpLiteral represents a regular expression literal.

--- a/ast/node.go
+++ b/ast/node.go
@@ -432,6 +432,26 @@ func (sl *StringLiteral) Idx1() file.Idx {
 // expression implements Expression.
 func (*StringLiteral) expression() {}
 
+// SpreadExpression represents a spread element, e.g. ...arr in a call argument
+// list or array literal.
+type SpreadExpression struct {
+	Value Expression
+	Idx   file.Idx
+}
+
+// Idx0 implements Node.
+func (se *SpreadExpression) Idx0() file.Idx {
+	return se.Idx
+}
+
+// Idx1 implements Node.
+func (se *SpreadExpression) Idx1() file.Idx {
+	return se.Value.Idx1()
+}
+
+// expression implements Expression.
+func (*SpreadExpression) expression() {}
+
 // TemplateLiteral represents a template literal, e.g. `abc${def}ghi`.
 //
 // Strings holds the cooked string segments and always contains exactly one

--- a/ast/node.go
+++ b/ast/node.go
@@ -351,7 +351,13 @@ func (*ObjectLiteral) expression() {}
 
 // ParameterList represents a parameter list.
 type ParameterList struct {
-	List    []*Identifier
+	List []*Identifier
+	// Defaults is parallel to List: Defaults[i], when non-nil, is the default
+	// value expression for parameter List[i].
+	Defaults []Expression
+	// Rest, when non-nil, is the name of a rest parameter (...name) which
+	// collects any trailing arguments into an array.
+	Rest    *Identifier
 	Opening file.Idx
 	Closing file.Idx
 }

--- a/ast/node.go
+++ b/ast/node.go
@@ -511,6 +511,21 @@ type ClassElement struct {
 	Method        *FunctionLiteral
 }
 
+// TaggedTemplateExpression represents a tagged template, e.g. tag`a${b}c`.
+type TaggedTemplateExpression struct {
+	Tag      Expression
+	Template *TemplateLiteral
+}
+
+// Idx0 implements Node.
+func (tte *TaggedTemplateExpression) Idx0() file.Idx { return tte.Tag.Idx0() }
+
+// Idx1 implements Node.
+func (tte *TaggedTemplateExpression) Idx1() file.Idx { return tte.Template.Idx1() }
+
+// expression implements Expression.
+func (*TaggedTemplateExpression) expression() {}
+
 // SuperExpression represents the `super` keyword.
 type SuperExpression struct {
 	Idx file.Idx
@@ -552,6 +567,7 @@ func (*SpreadExpression) expression() {}
 // the two: Strings[0] + Expressions[0] + Strings[1] + ... + Strings[n].
 type TemplateLiteral struct {
 	Strings     []string
+	Raw         []string // raw (un-cooked) string segments, parallel to Strings
 	Expressions []Expression
 	OpenQuote   file.Idx
 	CloseQuote  file.Idx

--- a/ast/node.go
+++ b/ast/node.go
@@ -479,6 +479,52 @@ type PatternProperty struct {
 	Target Expression
 }
 
+// ClassLiteral represents a class definition (declaration or expression).
+type ClassLiteral struct {
+	Name       *Identifier
+	SuperClass Expression // the extends clause, or nil
+	Body       []*ClassElement
+	Source     string
+	Class      file.Idx
+	RightBrace file.Idx
+}
+
+// Idx0 implements Node.
+func (cl *ClassLiteral) Idx0() file.Idx { return cl.Class }
+
+// Idx1 implements Node.
+func (cl *ClassLiteral) Idx1() file.Idx { return cl.RightBrace + 1 }
+
+// expression implements Expression.
+func (*ClassLiteral) expression() {}
+
+// statement implements Statement (a class declaration).
+func (*ClassLiteral) statement() {}
+
+// ClassElement is a single member of a class body.
+type ClassElement struct {
+	// Kind is "method", "get", "set" or "constructor".
+	Kind          string
+	Static        bool
+	Key           string
+	KeyExpression Expression // computed key, or nil
+	Method        *FunctionLiteral
+}
+
+// SuperExpression represents the `super` keyword.
+type SuperExpression struct {
+	Idx file.Idx
+}
+
+// Idx0 implements Node.
+func (se *SuperExpression) Idx0() file.Idx { return se.Idx }
+
+// Idx1 implements Node.
+func (se *SuperExpression) Idx1() file.Idx { return se.Idx + 5 }
+
+// expression implements Expression.
+func (*SuperExpression) expression() {}
+
 // SpreadExpression represents a spread element, e.g. ...arr in a call argument
 // list or array literal.
 type SpreadExpression struct {

--- a/ast/node.go
+++ b/ast/node.go
@@ -423,6 +423,31 @@ func (sl *StringLiteral) Idx1() file.Idx {
 // expression implements Expression.
 func (*StringLiteral) expression() {}
 
+// TemplateLiteral represents a template literal, e.g. `abc${def}ghi`.
+//
+// Strings holds the cooked string segments and always contains exactly one
+// more element than Expressions; the final string is rendered by interleaving
+// the two: Strings[0] + Expressions[0] + Strings[1] + ... + Strings[n].
+type TemplateLiteral struct {
+	Strings     []string
+	Expressions []Expression
+	OpenQuote   file.Idx
+	CloseQuote  file.Idx
+}
+
+// Idx0 implements Node.
+func (tl *TemplateLiteral) Idx0() file.Idx {
+	return tl.OpenQuote
+}
+
+// Idx1 implements Node.
+func (tl *TemplateLiteral) Idx1() file.Idx {
+	return tl.CloseQuote + 1
+}
+
+// expression implements Expression.
+func (*TemplateLiteral) expression() {}
+
 // ThisExpression represents a this expression.
 type ThisExpression struct {
 	Idx file.Idx

--- a/ast/node.go
+++ b/ast/node.go
@@ -351,29 +351,20 @@ func (*ObjectLiteral) expression() {}
 
 // ParameterList represents a parameter list.
 type ParameterList struct {
-	List []*Identifier
-	// Defaults is parallel to List: Defaults[i], when non-nil, is the default
-	// value expression for parameter List[i].
+	Rest     *Identifier
+	List     []*Identifier
 	Defaults []Expression
-	// Targets is parallel to List: Targets[i], when non-nil, is a destructuring
-	// pattern (ArrayPattern or ObjectPattern) bound by parameter i, in which
-	// case List[i] is a placeholder.
-	Targets []Expression
-	// Rest, when non-nil, is the name of a rest parameter (...name) which
-	// collects any trailing arguments into an array.
-	Rest    *Identifier
-	Opening file.Idx
-	Closing file.Idx
+	Targets  []Expression
+	Opening  file.Idx
+	Closing  file.Idx
 }
 
 // Property represents a property.
 type Property struct {
-	Value Expression
-	Key   string
-	Kind  string
-	// KeyExpression holds the key of a computed property, e.g. {[expr]: v}.
-	// When non-nil it is evaluated at runtime and Key is ignored.
+	Value         Expression
 	KeyExpression Expression
+	Key           string
+	Kind          string
 }
 
 // RegExpLiteral represents a regular expression literal.
@@ -438,11 +429,8 @@ func (*StringLiteral) expression() {}
 
 // ArrayPattern represents an array destructuring pattern, e.g. [a, b = 1, ...rest].
 type ArrayPattern struct {
-	// Elements holds the element targets; a nil entry is an elision (hole).
-	// A target may be an Identifier, a nested pattern, or an AssignExpression
-	// (target = default).
+	Rest         Expression
 	Elements     []Expression
-	Rest         Expression // rest target (...name), or nil
 	LeftBracket  file.Idx
 	RightBracket file.Idx
 }
@@ -458,8 +446,8 @@ func (*ArrayPattern) expression() {}
 
 // ObjectPattern represents an object destructuring pattern, e.g. {a, b: c = 1}.
 type ObjectPattern struct {
+	Rest       Expression
 	Properties []*PatternProperty
-	Rest       Expression // rest target (...name), or nil
 	LeftBrace  file.Idx
 	RightBrace file.Idx
 }
@@ -475,20 +463,17 @@ func (*ObjectPattern) expression() {}
 
 // PatternProperty is a single property of an ObjectPattern.
 type PatternProperty struct {
-	// Key is the (static) source property name; KeyExpression, when non-nil,
-	// is a computed key evaluated at runtime.
-	Key           string
 	KeyExpression Expression
-	// Target is the binding target, possibly an AssignExpression for a default.
-	Target Expression
+	Target        Expression
+	Key           string
 }
 
 // ClassLiteral represents a class definition (declaration or expression).
 type ClassLiteral struct {
+	SuperClass Expression
 	Name       *Identifier
-	SuperClass Expression // the extends clause, or nil
-	Body       []*ClassElement
 	Source     string
+	Body       []*ClassElement
 	Class      file.Idx
 	RightBrace file.Idx
 }
@@ -507,12 +492,11 @@ func (*ClassLiteral) statement() {}
 
 // ClassElement is a single member of a class body.
 type ClassElement struct {
-	// Kind is "method", "get", "set" or "constructor".
-	Kind          string
-	Static        bool
-	Key           string
-	KeyExpression Expression // computed key, or nil
+	KeyExpression Expression
 	Method        *FunctionLiteral
+	Kind          string
+	Key           string
+	Static        bool
 }
 
 // TaggedTemplateExpression represents a tagged template, e.g. tag`a${b}c`.
@@ -638,11 +622,9 @@ func (*UnaryExpression) expression() {}
 // VariableExpression represents a variable expression.
 type VariableExpression struct {
 	Initializer Expression
+	Target      Expression
 	Name        string
 	Idx         file.Idx
-	// Target, when non-nil, is a destructuring binding pattern (ArrayPattern or
-	// ObjectPattern) used in place of a plain Name.
-	Target Expression
 }
 
 // Idx0 implements Node.

--- a/ast/node.go
+++ b/ast/node.go
@@ -355,6 +355,10 @@ type ParameterList struct {
 	// Defaults is parallel to List: Defaults[i], when non-nil, is the default
 	// value expression for parameter List[i].
 	Defaults []Expression
+	// Targets is parallel to List: Targets[i], when non-nil, is a destructuring
+	// pattern (ArrayPattern or ObjectPattern) bound by parameter i, in which
+	// case List[i] is a placeholder.
+	Targets []Expression
 	// Rest, when non-nil, is the name of a rest parameter (...name) which
 	// collects any trailing arguments into an array.
 	Rest    *Identifier

--- a/ast/node.go
+++ b/ast/node.go
@@ -737,6 +737,9 @@ type ForInStatement struct {
 	// Lexical is token.LET or token.CONST when Into declares a block-scoped
 	// loop variable.
 	Lexical token.Token
+	// Of distinguishes a for-of loop (iterating values) from a for-in loop
+	// (iterating keys).
+	Of bool
 }
 
 // Idx0 implements Node.

--- a/ast/node.go
+++ b/ast/node.go
@@ -432,6 +432,53 @@ func (sl *StringLiteral) Idx1() file.Idx {
 // expression implements Expression.
 func (*StringLiteral) expression() {}
 
+// ArrayPattern represents an array destructuring pattern, e.g. [a, b = 1, ...rest].
+type ArrayPattern struct {
+	// Elements holds the element targets; a nil entry is an elision (hole).
+	// A target may be an Identifier, a nested pattern, or an AssignExpression
+	// (target = default).
+	Elements     []Expression
+	Rest         Expression // rest target (...name), or nil
+	LeftBracket  file.Idx
+	RightBracket file.Idx
+}
+
+// Idx0 implements Node.
+func (ap *ArrayPattern) Idx0() file.Idx { return ap.LeftBracket }
+
+// Idx1 implements Node.
+func (ap *ArrayPattern) Idx1() file.Idx { return ap.RightBracket + 1 }
+
+// expression implements Expression.
+func (*ArrayPattern) expression() {}
+
+// ObjectPattern represents an object destructuring pattern, e.g. {a, b: c = 1}.
+type ObjectPattern struct {
+	Properties []*PatternProperty
+	Rest       Expression // rest target (...name), or nil
+	LeftBrace  file.Idx
+	RightBrace file.Idx
+}
+
+// Idx0 implements Node.
+func (op *ObjectPattern) Idx0() file.Idx { return op.LeftBrace }
+
+// Idx1 implements Node.
+func (op *ObjectPattern) Idx1() file.Idx { return op.RightBrace + 1 }
+
+// expression implements Expression.
+func (*ObjectPattern) expression() {}
+
+// PatternProperty is a single property of an ObjectPattern.
+type PatternProperty struct {
+	// Key is the (static) source property name; KeyExpression, when non-nil,
+	// is a computed key evaluated at runtime.
+	Key           string
+	KeyExpression Expression
+	// Target is the binding target, possibly an AssignExpression for a default.
+	Target Expression
+}
+
 // SpreadExpression represents a spread element, e.g. ...arr in a call argument
 // list or array literal.
 type SpreadExpression struct {
@@ -527,6 +574,9 @@ type VariableExpression struct {
 	Initializer Expression
 	Name        string
 	Idx         file.Idx
+	// Target, when non-nil, is a destructuring binding pattern (ArrayPattern or
+	// ObjectPattern) used in place of a plain Name.
+	Target Expression
 }
 
 // Idx0 implements Node.

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -211,6 +211,29 @@ func Walk(v Visitor, n Node) {
 		if n != nil {
 			Walk(v, n.Initializer)
 		}
+	case *ArrayPattern:
+		if n != nil {
+			for _, e := range n.Elements {
+				if e != nil {
+					Walk(v, e)
+				}
+			}
+			if n.Rest != nil {
+				Walk(v, n.Rest)
+			}
+		}
+	case *ObjectPattern:
+		if n != nil {
+			for _, prop := range n.Properties {
+				if prop.KeyExpression != nil {
+					Walk(v, prop.KeyExpression)
+				}
+				Walk(v, prop.Target)
+			}
+			if n.Rest != nil {
+				Walk(v, n.Rest)
+			}
+		}
 	case *VariableStatement:
 		if n != nil {
 			for _, e := range n.List {

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -213,6 +213,12 @@ func Walk(v Visitor, n Node) {
 				Walk(v, e)
 			}
 		}
+	case *LexicalDeclaration:
+		if n != nil {
+			for _, e := range n.List {
+				Walk(v, e)
+			}
+		}
 	case *WhileStatement:
 		if n != nil {
 			Walk(v, n.Test)

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -175,6 +175,19 @@ func Walk(v Visitor, n Node) {
 			}
 		}
 	case *StringLiteral:
+	case *SuperExpression:
+	case *ClassLiteral:
+		if n != nil {
+			if n.SuperClass != nil {
+				Walk(v, n.SuperClass)
+			}
+			for _, element := range n.Body {
+				if element.KeyExpression != nil {
+					Walk(v, element.KeyExpression)
+				}
+				Walk(v, element.Method)
+			}
+		}
 	case *SpreadExpression:
 		if n != nil {
 			Walk(v, n.Value)

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -175,6 +175,10 @@ func Walk(v Visitor, n Node) {
 			}
 		}
 	case *StringLiteral:
+	case *SpreadExpression:
+		if n != nil {
+			Walk(v, n.Value)
+		}
 	case *TemplateLiteral:
 		if n != nil {
 			for _, e := range n.Expressions {

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -172,6 +172,12 @@ func Walk(v Visitor, n Node) {
 			}
 		}
 	case *StringLiteral:
+	case *TemplateLiteral:
+		if n != nil {
+			for _, e := range n.Expressions {
+				Walk(v, e)
+			}
+		}
 	case *SwitchStatement:
 		if n != nil {
 			Walk(v, n.Discriminant)

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -198,6 +198,11 @@ func Walk(v Visitor, n Node) {
 				Walk(v, e)
 			}
 		}
+	case *TaggedTemplateExpression:
+		if n != nil {
+			Walk(v, n.Tag)
+			Walk(v, n.Template)
+		}
 	case *SwitchStatement:
 		if n != nil {
 			Walk(v, n.Discriminant)

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -151,6 +151,9 @@ func Walk(v Visitor, n Node) {
 	case *ObjectLiteral:
 		if n != nil {
 			for _, p := range n.Value {
+				if p.KeyExpression != nil {
+					Walk(v, p.KeyExpression)
+				}
 				Walk(v, p.Value)
 			}
 		}

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -42,6 +42,29 @@ func builtinStringFromCharCode(call FunctionCall) Value {
 	return string16Value(chrList)
 }
 
+func builtinStringRaw(call FunctionCall) Value {
+	template := call.Argument(0)
+	if !template.IsObject() {
+		return stringValue("")
+	}
+	raw := template.object().get("raw")
+	if !raw.IsObject() {
+		return stringValue("")
+	}
+	rawObject := raw.object()
+	length := int64(toUint32(rawObject.get(propertyLength)))
+
+	var b strings.Builder
+	for i := int64(0); i < length; i++ {
+		b.WriteString(rawObject.get(arrayIndexToString(i)).string())
+		// Interleave the substitution that follows each segment but the last.
+		if i+1 < length && int(i)+1 < len(call.ArgumentList) {
+			b.WriteString(call.ArgumentList[i+1].string())
+		}
+	}
+	return stringValue(b.String())
+}
+
 func builtinStringCharAt(call FunctionCall) Value {
 	checkObjectCoercible(call.runtime, call.This)
 	idx := int(call.Argument(0).number().int64)

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -55,7 +55,7 @@ func builtinStringRaw(call FunctionCall) Value {
 	length := int64(toUint32(rawObject.get(propertyLength)))
 
 	var b strings.Builder
-	for i := int64(0); i < length; i++ {
+	for i := range length {
 		b.WriteString(rawObject.get(arrayIndexToString(i)).string())
 		// Interleave the substitution that follows each segment but the last.
 		if i+1 < length && int(i)+1 < len(call.ArgumentList) {

--- a/class_test.go
+++ b/class_test.go
@@ -1,0 +1,132 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestClassBasic(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            class C { constructor(x) { this.x = x; } get() { return this.x; } }
+            new C(5).get();
+        `, 5)
+
+		// typeof a class is "function".
+		test(`class C {} typeof C;`, "function")
+
+		// Methods live on the prototype.
+		test(`
+            class C { foo() { return 1; } }
+            var c = new C();
+            [c.foo(), C.prototype.foo === c.foo].join(",");
+        `, "1,true")
+
+		// Static methods.
+		test(`class C { static bar() { return 42; } } C.bar();`, 42)
+
+		// Method chaining via `this`.
+		test(`
+            class C { constructor() { this.list = []; } add(x) { this.list.push(x); return this; } }
+            var c = new C();
+            c.add(1).add(2);
+            c.list.join(",");
+        `, "1,2")
+
+		// Class expression.
+		test(`
+            var C = class { m() { return "expr"; } };
+            new C().m();
+        `, "expr")
+
+		// Computed method name.
+		test(`
+            class C { ["dyn" + "amic"]() { return "computed"; } }
+            new C().dynamic();
+        `, "computed")
+	})
+}
+
+func TestClassAccessors(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`class C { get v() { return 9; } } new C().v;`, 9)
+
+		test(`
+            var store = 0;
+            class C { set v(n) { store = n; } }
+            var c = new C();
+            c.v = 3;
+            store;
+        `, 3)
+
+		// Getter and setter on the same property.
+		test(`
+            class C {
+                get v() { return this._v; }
+                set v(n) { this._v = n * 2; }
+            }
+            var c = new C();
+            c.v = 5;
+            c.v;
+        `, 10)
+	})
+}
+
+func TestClassInheritance(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// instanceof through the chain.
+		test(`class A {} class B extends A {} (new B()) instanceof A;`, true)
+
+		// Inherited methods.
+		test(`
+            class A { hi() { return "a"; } }
+            class B extends A {}
+            new B().hi();
+        `, "a")
+
+		// A default derived constructor forwards to super.
+		test(`
+            class A { constructor() { this.t = "A"; } }
+            class B extends A {}
+            new B().t;
+        `, "A")
+
+		// Explicit super(...) call.
+		test(`
+            class A { constructor(n) { this.n = n; } }
+            class B extends A { constructor(n) { super(n); } }
+            new B(7).n;
+        `, 7)
+
+		// super.method().
+		test(`
+            class A { who() { return "A"; } }
+            class B extends A { who() { return "B+" + super.who(); } }
+            new B().who();
+        `, "B+A")
+
+		// Overriding with full example.
+		test(`
+            class Animal {
+                constructor(name) { this.name = name; }
+                speak() { return this.name + " makes a sound"; }
+            }
+            class Dog extends Animal {
+                speak() { return this.name + " barks"; }
+            }
+            new Dog("Rex").speak();
+        `, "Rex barks")
+
+		// Static inheritance.
+		test(`
+            class A { static make() { return "made"; } }
+            class B extends A {}
+            B.make();
+        `, "made")
+	})
+}

--- a/cmpl_evaluate.go
+++ b/cmpl_evaluate.go
@@ -43,6 +43,11 @@ func (rt *runtime) cmplCallNodeFunction(function *object, stash *fnStash, node *
 		if value.IsUndefined() && index < len(node.parameterDefaults) && node.parameterDefaults[index] != nil {
 			value = rt.cmplEvaluateNodeExpression(node.parameterDefaults[index]).resolve()
 		}
+		// A destructuring parameter binds the argument against its pattern.
+		if index < len(node.parameterTargets) && node.parameterTargets[index] != nil {
+			rt.bindPattern(node.parameterTargets[index], value, bindLet)
+			continue
+		}
 		// strict = false
 		rt.scope.lexical.setValue(name, value, false)
 	}

--- a/cmpl_evaluate.go
+++ b/cmpl_evaluate.go
@@ -37,8 +37,23 @@ func (rt *runtime) cmplCallNodeFunction(function *object, stash *fnStash, node *
 			value = argumentList[index]
 			indexOfParameterName[index] = name
 		}
+		// Apply a default value when the argument is missing or undefined.
+		// Defaults are evaluated left-to-right and may reference earlier
+		// parameters, which have already been bound in this scope.
+		if value.IsUndefined() && index < len(node.parameterDefaults) && node.parameterDefaults[index] != nil {
+			value = rt.cmplEvaluateNodeExpression(node.parameterDefaults[index]).resolve()
+		}
 		// strict = false
 		rt.scope.lexical.setValue(name, value, false)
+	}
+
+	// Collect any remaining arguments into the rest parameter array.
+	if node.restParameter != "" {
+		rest := []Value{}
+		if len(argumentList) > len(node.parameterList) {
+			rest = append(rest, argumentList[len(node.parameterList):]...)
+		}
+		rt.scope.lexical.setValue(node.restParameter, objectValue(rt.newArrayOf(rest)), false)
 	}
 
 	if !node.isArrow && !argumentsFound {

--- a/cmpl_evaluate.go
+++ b/cmpl_evaluate.go
@@ -37,7 +37,7 @@ func (rt *runtime) cmplCallNodeFunction(function *object, stash *fnStash, node *
 		rt.scope.lexical.setValue(name, value, false)
 	}
 
-	if !argumentsFound {
+	if !node.isArrow && !argumentsFound {
 		arguments := rt.newArgumentsObject(indexOfParameterName, stash, len(argumentList))
 		arguments.defineProperty("callee", objectValue(function), 0o101, false)
 		stash.arguments = arguments

--- a/cmpl_evaluate.go
+++ b/cmpl_evaluate.go
@@ -12,6 +12,10 @@ func (rt *runtime) cmplEvaluateNodeProgram(node *nodeProgram, eval bool) Value {
 	rt.cmplFunctionDeclaration(node.functionList)
 	rt.cmplVariableDeclaration(node.varList)
 	rt.scope.frame.file = node.file
+	if node.lexical {
+		restore := rt.enterLexicalScope()
+		defer restore()
+	}
 	return rt.cmplEvaluateNodeStatementList(node.body)
 }
 

--- a/cmpl_evaluate_class.go
+++ b/cmpl_evaluate_class.go
@@ -132,10 +132,12 @@ func (rt *runtime) defineClassAccessor(target *object, key string, fn *object, i
 // method or constructor, used to resolve `super`.
 func (rt *runtime) currentHomeObject() *object {
 	for sc := rt.scope; sc != nil; sc = sc.outer {
-		if obj, ok := sc.frame.fn.(*object); ok {
-			if fn, ok := obj.value.(nodeFunctionObject); ok && fn.homeObject != nil {
-				return fn.homeObject
-			}
+		obj, ok := sc.frame.fn.(*object)
+		if !ok {
+			continue
+		}
+		if fn, isNode := obj.value.(nodeFunctionObject); isNode && fn.homeObject != nil {
+			return fn.homeObject
 		}
 	}
 	return nil

--- a/cmpl_evaluate_class.go
+++ b/cmpl_evaluate_class.go
@@ -1,0 +1,202 @@
+package otto
+
+// cmplEvaluateNodeClassStatement evaluates a class declaration, binding the
+// class constructor to its name in the current lexical environment.
+func (rt *runtime) cmplEvaluateNodeClassStatement(node *nodeClassStatement) Value {
+	value := rt.cmplEvaluateNodeClassLiteral(node.class)
+	if node.name != "" {
+		rt.declareLexicalBinding(node.name, value, false)
+	}
+	return emptyValue
+}
+
+// cmplEvaluateNodeClassLiteral builds a class: a constructor function whose
+// prototype carries the instance methods, with static members on the
+// constructor itself and the prototype/static chains wired up for extends.
+func (rt *runtime) cmplEvaluateNodeClassLiteral(node *nodeClassLiteral) Value {
+	var superConstructor *object
+	var superPrototype *object
+	hasSuper := node.superClass != nil
+	if hasSuper {
+		superValue := rt.cmplEvaluateNodeExpression(node.superClass).resolve()
+		if !superValue.IsNull() {
+			if !superValue.IsFunction() {
+				panic(rt.panicTypeError("Class extends value is not a constructor or null"))
+			}
+			superConstructor = superValue.object()
+			if proto := superConstructor.get("prototype"); proto.IsObject() {
+				superPrototype = proto.object()
+			}
+		}
+	}
+
+	// The prototype object holding instance methods.
+	prototype := rt.newObject()
+	if hasSuper {
+		prototype.prototype = superPrototype
+	}
+
+	// Locate an explicit constructor, if any.
+	var constructorNode *nodeFunctionLiteral
+	for i := range node.elements {
+		if node.elements[i].kind == "constructor" {
+			constructorNode = node.elements[i].method
+		}
+	}
+
+	var constructor *object
+	if constructorNode != nil {
+		constructor = rt.newNodeFunction(constructorNode, rt.scope.lexical)
+	} else {
+		// Synthesise a default constructor.
+		empty := &nodeFunctionLiteral{
+			name: node.name,
+			body: &nodeBlockStatement{},
+			file: rt.scope.frame.file,
+		}
+		constructor = rt.newNodeFunction(empty, rt.scope.lexical)
+		if hasSuper {
+			// A default derived constructor forwards its arguments to super().
+			fn := constructor.value.(nodeFunctionObject)
+			fn.defaultDerivedCtor = true
+			constructor.value = fn
+		}
+	}
+
+	constructor.defineProperty("prototype", objectValue(prototype), 0o000, false)
+	constructor.defineProperty("name", stringValue(node.name), 0o001, false)
+	prototype.defineProperty("constructor", objectValue(constructor), 0o101, false)
+	rt.setHomeObject(constructor, prototype)
+	if superConstructor != nil {
+		// Static inheritance: the constructor's prototype is the super constructor.
+		constructor.prototype = superConstructor
+	}
+
+	// Define the methods, getters and setters.
+	for i := range node.elements {
+		element := &node.elements[i]
+		if element.kind == "constructor" {
+			continue
+		}
+
+		target := prototype
+		if element.static {
+			target = constructor
+		}
+
+		key := element.key
+		if element.keyExpr != nil {
+			key = rt.cmplEvaluateNodeExpression(element.keyExpr).resolve().string()
+		}
+
+		fn := rt.newNodeFunction(element.method, rt.scope.lexical)
+		rt.setHomeObject(fn, target)
+
+		switch element.kind {
+		case "get":
+			rt.defineClassAccessor(target, key, fn, true)
+		case "set":
+			rt.defineClassAccessor(target, key, fn, false)
+		default: // method
+			target.defineProperty(key, objectValue(fn), 0o101, false)
+		}
+	}
+
+	return objectValue(constructor)
+}
+
+// setHomeObject records the object a function was defined on, for super.
+func (rt *runtime) setHomeObject(fn *object, home *object) {
+	value := fn.value.(nodeFunctionObject)
+	value.homeObject = home
+	fn.value = value
+}
+
+// defineClassAccessor defines (or augments) a getter/setter accessor property.
+func (rt *runtime) defineClassAccessor(target *object, key string, fn *object, isGetter bool) {
+	getset := propertyGetSet{}
+	if existing, exists := target.property[key]; exists {
+		if current, ok := existing.value.(propertyGetSet); ok {
+			getset = current
+		}
+	}
+	if isGetter {
+		getset[0] = fn
+	} else {
+		getset[1] = fn
+	}
+	target.defineOwnProperty(key, property{value: getset, mode: 0o101}, false)
+}
+
+// currentHomeObject returns the home object of the nearest enclosing class
+// method or constructor, used to resolve `super`.
+func (rt *runtime) currentHomeObject() *object {
+	for sc := rt.scope; sc != nil; sc = sc.outer {
+		if obj, ok := sc.frame.fn.(*object); ok {
+			if fn, ok := obj.value.(nodeFunctionObject); ok && fn.homeObject != nil {
+				return fn.homeObject
+			}
+		}
+	}
+	return nil
+}
+
+// superConstructor returns the parent constructor for a super(...) call.
+func (rt *runtime) superConstructor() *object {
+	home := rt.currentHomeObject()
+	if home == nil || home.prototype == nil {
+		panic(rt.panicSyntaxError("'super' keyword unexpected here"))
+	}
+	ctor := home.prototype.get("constructor")
+	if !ctor.IsFunction() {
+		panic(rt.panicTypeError("Super constructor is not a constructor"))
+	}
+	return ctor.object()
+}
+
+// evaluateArgumentList evaluates a call/new argument list, expanding spreads.
+func (rt *runtime) evaluateArgumentList(nodes []nodeExpression) []Value {
+	argumentList := []Value{}
+	for _, argumentNode := range nodes {
+		if spread, ok := argumentNode.(*nodeSpreadExpression); ok {
+			value := rt.cmplEvaluateNodeExpression(spread.value).resolve()
+			argumentList = append(argumentList, rt.spreadIterable(value)...)
+			continue
+		}
+		argumentList = append(argumentList, rt.cmplEvaluateNodeExpression(argumentNode).resolve())
+	}
+	return argumentList
+}
+
+// evaluateSuperConstructorCall handles super(...), invoking the parent
+// constructor on the current `this`.
+func (rt *runtime) evaluateSuperConstructorCall(node *nodeCallExpression) Value {
+	parent := rt.superConstructor()
+	argumentList := rt.evaluateArgumentList(node.argumentList)
+	this := objectValue(rt.scope.this)
+	parent.call(this, argumentList, false, frame{})
+	return emptyValue
+}
+
+// evaluateSuperMethodCall handles super.method(...) and super[expr](...),
+// looking the method up on the parent prototype but calling it with the
+// current `this`.
+func (rt *runtime) evaluateSuperMethodCall(key string, node *nodeCallExpression) Value {
+	proto := rt.superPrototype()
+	method := proto.get(key)
+	if !method.IsFunction() {
+		panic(rt.panicTypeError("(intermediate value).%s is not a function", key))
+	}
+	argumentList := rt.evaluateArgumentList(node.argumentList)
+	this := objectValue(rt.scope.this)
+	return method.object().call(this, argumentList, false, frame{})
+}
+
+// superPrototype returns the object on which `super.x` member accesses resolve.
+func (rt *runtime) superPrototype() *object {
+	home := rt.currentHomeObject()
+	if home == nil {
+		panic(rt.panicSyntaxError("'super' keyword unexpected here"))
+	}
+	return home.prototype
+}

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -319,21 +319,25 @@ func (rt *runtime) cmplEvaluateNodeNewExpression(node *nodeNewExpression) Value 
 func (rt *runtime) cmplEvaluateNodeObjectLiteral(node *nodeObjectLiteral) Value {
 	result := rt.newObject()
 	for _, prop := range node.value {
+		key := prop.key
+		if prop.keyExpression != nil {
+			key = rt.cmplEvaluateNodeExpression(prop.keyExpression).resolve().string()
+		}
 		switch prop.kind {
 		case "value":
-			result.defineProperty(prop.key, rt.cmplEvaluateNodeExpression(prop.value).resolve(), 0o111, false)
+			result.defineProperty(key, rt.cmplEvaluateNodeExpression(prop.value).resolve(), 0o111, false)
 		case "get":
 			getter := rt.newNodeFunction(prop.value.(*nodeFunctionLiteral), rt.scope.lexical)
 			descriptor := property{}
 			descriptor.mode = 0o211
 			descriptor.value = propertyGetSet{getter, nil}
-			result.defineOwnProperty(prop.key, descriptor, false)
+			result.defineOwnProperty(key, descriptor, false)
 		case "set":
 			setter := rt.newNodeFunction(prop.value.(*nodeFunctionLiteral), rt.scope.lexical)
 			descriptor := property{}
 			descriptor.mode = 0o211
 			descriptor.value = propertyGetSet{nil, setter}
-			result.defineOwnProperty(prop.key, descriptor, false)
+			result.defineOwnProperty(key, descriptor, false)
 		default:
 			panic(fmt.Sprintf("unknown node object literal property kind %T", prop.kind))
 		}

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -53,7 +53,14 @@ func (rt *runtime) cmplEvaluateNodeExpression(node nodeExpression) Value {
 			local = rt.newDeclarationStash(local)
 		}
 
-		value := objectValue(rt.newNodeFunction(node, local))
+		fnObj := rt.newNodeFunction(node, local)
+		if node.isArrow {
+			// Capture the enclosing `this` for lexical binding at call time.
+			fn := fnObj.value.(nodeFunctionObject)
+			fn.this = objectValue(rt.scope.this)
+			fnObj.value = fn
+		}
+		value := objectValue(fnObj)
 		if node.name != "" {
 			local.createBinding(node.name, false, value)
 		}

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	goruntime "runtime"
+	"strings"
 
 	"github.com/robertkrimen/otto/token"
 )
@@ -92,6 +93,16 @@ func (rt *runtime) cmplEvaluateNodeExpression(node nodeExpression) Value {
 
 	case *nodeSequenceExpression:
 		return rt.cmplEvaluateNodeSequenceExpression(node)
+
+	case *nodeTemplateLiteral:
+		var b strings.Builder
+		for i, str := range node.strings {
+			b.WriteString(str)
+			if i < len(node.expressions) {
+				b.WriteString(rt.cmplEvaluateNodeExpression(node.expressions[i]).resolve().string())
+			}
+		}
+		return stringValue(b.String())
 
 	case *nodeThisExpression:
 		return objectValue(rt.scope.this)

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -112,6 +112,9 @@ func (rt *runtime) cmplEvaluateNodeExpression(node nodeExpression) Value {
 		// which are handled by the call and member evaluators.
 		panic(rt.panicSyntaxError("'super' keyword unexpected here"))
 
+	case *nodeTaggedTemplate:
+		return rt.cmplEvaluateNodeTaggedTemplate(node)
+
 	case *nodeThisExpression:
 		return objectValue(rt.scope.this)
 
@@ -317,6 +320,40 @@ func (rt *runtime) cmplEvaluateNodeConditionalExpression(node *nodeConditionalEx
 		return rt.cmplEvaluateNodeExpression(node.consequent)
 	}
 	return rt.cmplEvaluateNodeExpression(node.alternate)
+}
+
+func (rt *runtime) cmplEvaluateNodeTaggedTemplate(node *nodeTaggedTemplate) Value {
+	tag := rt.cmplEvaluateNodeExpression(node.tag)
+
+	// A tag of the form obj.fn`...` is called with `this` = obj.
+	this := Value{}
+	if rf, ok := tag.reference().(*propertyReference); ok && rf != nil {
+		this = objectValue(rf.base)
+	}
+
+	fn := tag.resolve()
+	if !fn.IsFunction() {
+		panic(rt.panicTypeError("Tagged template tag is not a function"))
+	}
+
+	// Build the strings array, carrying the raw segments on its `raw` property.
+	cooked := make([]Value, len(node.quasis))
+	for i, s := range node.quasis {
+		cooked[i] = stringValue(s)
+	}
+	stringsArray := rt.newArrayOf(cooked)
+	raw := make([]Value, len(node.raw))
+	for i, s := range node.raw {
+		raw[i] = stringValue(s)
+	}
+	stringsArray.defineProperty("raw", objectValue(rt.newArrayOf(raw)), 0o000, false)
+
+	argumentList := []Value{objectValue(stringsArray)}
+	for _, expr := range node.expressions {
+		argumentList = append(argumentList, rt.cmplEvaluateNodeExpression(expr).resolve())
+	}
+
+	return fn.object().call(this, argumentList, false, frame{})
 }
 
 func (rt *runtime) cmplEvaluateNodeDotExpression(node *nodeDotExpression) Value {

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -163,6 +163,14 @@ func (rt *runtime) spreadIterable(value Value) []Value {
 }
 
 func (rt *runtime) cmplEvaluateNodeAssignExpression(node *nodeAssignExpression) Value {
+	// Destructuring assignment: [a, b] = ... or ({a, b} = ...).
+	switch node.left.(type) {
+	case *nodeArrayPattern, *nodeObjectPattern:
+		rightValue := rt.cmplEvaluateNodeExpression(node.right).resolve()
+		rt.bindPattern(node.left, rightValue, bindAssign)
+		return rightValue
+	}
+
 	left := rt.cmplEvaluateNodeExpression(node.left)
 	right := rt.cmplEvaluateNodeExpression(node.right)
 	rightValue := right.resolve()
@@ -488,6 +496,16 @@ func (rt *runtime) cmplEvaluateNodeUnaryExpression(node *nodeUnaryExpression) Va
 }
 
 func (rt *runtime) cmplEvaluateNodeVariableExpression(node *nodeVariableExpression) Value {
+	if node.target != nil {
+		// var destructuring: the bound names are already hoisted, so assign
+		// into them.
+		value := Value{}
+		if node.initializer != nil {
+			value = rt.cmplEvaluateNodeExpression(node.initializer).resolve()
+		}
+		rt.bindPattern(node.target, value, bindAssign)
+		return emptyValue
+	}
 	if node.initializer != nil {
 		// FIXME If reference is nil
 		left := getIdentifierReference(rt, rt.scope.lexical, node.name, false, at(node.idx))

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -104,6 +104,14 @@ func (rt *runtime) cmplEvaluateNodeExpression(node nodeExpression) Value {
 		}
 		return stringValue(b.String())
 
+	case *nodeClassLiteral:
+		return rt.cmplEvaluateNodeClassLiteral(node)
+
+	case *nodeSuperExpression:
+		// A bare `super` is only meaningful as part of super(...) or super.x,
+		// which are handled by the call and member evaluators.
+		panic(rt.panicSyntaxError("'super' keyword unexpected here"))
+
 	case *nodeThisExpression:
 		return objectValue(rt.scope.this)
 
@@ -230,6 +238,21 @@ func (rt *runtime) cmplEvaluateNodeBracketExpression(node *nodeBracketExpression
 }
 
 func (rt *runtime) cmplEvaluateNodeCallExpression(node *nodeCallExpression, withArgumentList []interface{}) Value {
+	// super(...) and super.method(...) calls.
+	switch callee := node.callee.(type) {
+	case *nodeSuperExpression:
+		return rt.evaluateSuperConstructorCall(node)
+	case *nodeDotExpression:
+		if _, ok := callee.left.(*nodeSuperExpression); ok {
+			return rt.evaluateSuperMethodCall(callee.identifier, node)
+		}
+	case *nodeBracketExpression:
+		if _, ok := callee.left.(*nodeSuperExpression); ok {
+			key := rt.cmplEvaluateNodeExpression(callee.member).resolve().string()
+			return rt.evaluateSuperMethodCall(key, node)
+		}
+	}
+
 	this := Value{}
 	callee := rt.cmplEvaluateNodeExpression(node.callee)
 
@@ -237,14 +260,7 @@ func (rt *runtime) cmplEvaluateNodeCallExpression(node *nodeCallExpression, with
 	if withArgumentList != nil {
 		argumentList = rt.toValueArray(withArgumentList...)
 	} else {
-		for _, argumentNode := range node.argumentList {
-			if spread, ok := argumentNode.(*nodeSpreadExpression); ok {
-				value := rt.cmplEvaluateNodeExpression(spread.value).resolve()
-				argumentList = append(argumentList, rt.spreadIterable(value)...)
-				continue
-			}
-			argumentList = append(argumentList, rt.cmplEvaluateNodeExpression(argumentNode).resolve())
-		}
+		argumentList = rt.evaluateArgumentList(node.argumentList)
 	}
 
 	eval := false // Whether this call is a (candidate for) direct call to eval
@@ -304,6 +320,10 @@ func (rt *runtime) cmplEvaluateNodeConditionalExpression(node *nodeConditionalEx
 }
 
 func (rt *runtime) cmplEvaluateNodeDotExpression(node *nodeDotExpression) Value {
+	if _, ok := node.left.(*nodeSuperExpression); ok {
+		// super.x: read the member from the parent prototype.
+		return rt.superPrototype().get(node.identifier)
+	}
 	target := rt.cmplEvaluateNodeExpression(node.left)
 	targetValue := target.resolve()
 	// TODO Pass in base value as-is, and defer toObject till later?

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -164,7 +164,7 @@ func (rt *runtime) spreadIterable(value Value) []Value {
 		obj := value.object()
 		length := int64(toUint32(obj.get(propertyLength)))
 		out := make([]Value, 0, length)
-		for i := int64(0); i < length; i++ {
+		for i := range length {
 			out = append(out, obj.get(arrayIndexToString(i)))
 		}
 		return out
@@ -259,7 +259,7 @@ func (rt *runtime) cmplEvaluateNodeCallExpression(node *nodeCallExpression, with
 	this := Value{}
 	callee := rt.cmplEvaluateNodeExpression(node.callee)
 
-	argumentList := []Value{}
+	var argumentList []Value
 	if withArgumentList != nil {
 		argumentList = rt.toValueArray(withArgumentList...)
 	} else {

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -121,9 +121,13 @@ func (rt *runtime) cmplEvaluateNodeArrayLiteral(node *nodeArrayLiteral) Value {
 	valueArray := []Value{}
 
 	for _, node := range node.value {
-		if node == nil {
+		switch node := node.(type) {
+		case nil:
 			valueArray = append(valueArray, emptyValue)
-		} else {
+		case *nodeSpreadExpression:
+			spread := rt.cmplEvaluateNodeExpression(node.value).resolve()
+			valueArray = append(valueArray, rt.spreadIterable(spread)...)
+		default:
 			valueArray = append(valueArray, rt.cmplEvaluateNodeExpression(node).resolve())
 		}
 	}
@@ -131,6 +135,31 @@ func (rt *runtime) cmplEvaluateNodeArrayLiteral(node *nodeArrayLiteral) Value {
 	result := rt.newArrayOf(valueArray)
 
 	return objectValue(result)
+}
+
+// spreadIterable expands a spread value (...value) into a slice of values. It
+// supports arrays, strings (by code point) and array-like objects with a
+// length property.
+func (rt *runtime) spreadIterable(value Value) []Value {
+	switch value.kind {
+	case valueString:
+		runes := []rune(value.string())
+		out := make([]Value, len(runes))
+		for i, r := range runes {
+			out[i] = stringValue(string(r))
+		}
+		return out
+	case valueObject:
+		obj := value.object()
+		length := int64(toUint32(obj.get(propertyLength)))
+		out := make([]Value, 0, length)
+		for i := int64(0); i < length; i++ {
+			out = append(out, obj.get(arrayIndexToString(i)))
+		}
+		return out
+	default:
+		panic(rt.panicTypeError("%v is not iterable", value))
+	}
 }
 
 func (rt *runtime) cmplEvaluateNodeAssignExpression(node *nodeAssignExpression) Value {
@@ -201,6 +230,11 @@ func (rt *runtime) cmplEvaluateNodeCallExpression(node *nodeCallExpression, with
 		argumentList = rt.toValueArray(withArgumentList...)
 	} else {
 		for _, argumentNode := range node.argumentList {
+			if spread, ok := argumentNode.(*nodeSpreadExpression); ok {
+				value := rt.cmplEvaluateNodeExpression(spread.value).resolve()
+				argumentList = append(argumentList, rt.spreadIterable(value)...)
+				continue
+			}
 			argumentList = append(argumentList, rt.cmplEvaluateNodeExpression(argumentNode).resolve())
 		}
 	}

--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -23,16 +23,10 @@ func (rt *runtime) cmplEvaluateNodeStatement(node nodeStatement) Value {
 
 	switch node := node.(type) {
 	case *nodeBlockStatement:
-		labels := rt.labels
-		rt.labels = nil
+		return rt.cmplEvaluateNodeBlockStatement(node)
 
-		value := rt.cmplEvaluateNodeStatementList(node.list)
-		if value.kind == valueResult {
-			if value.evaluateBreak(labels) == resultBreak {
-				return emptyValue
-			}
-		}
-		return value
+	case *nodeLexicalDeclaration:
+		return rt.cmplEvaluateNodeLexicalDeclaration(node)
 
 	case *nodeBranchStatement:
 		target := node.label
@@ -168,6 +162,70 @@ resultBreak:
 	return result
 }
 
+// cmplEvaluateNodeBlockStatement evaluates a block, introducing a fresh lexical
+// environment record when the block contains let/const declarations.
+func (rt *runtime) cmplEvaluateNodeBlockStatement(node *nodeBlockStatement) Value {
+	labels := rt.labels
+	rt.labels = nil
+
+	if node.lexical {
+		restore := rt.enterLexicalScope()
+		defer restore()
+	}
+
+	value := rt.cmplEvaluateNodeStatementList(node.list)
+	if value.kind == valueResult {
+		if value.evaluateBreak(labels) == resultBreak {
+			return emptyValue
+		}
+	}
+	return value
+}
+
+// enterLexicalScope pushes a new declarative environment record as the current
+// lexical environment, returning a function that restores the previous one.
+func (rt *runtime) enterLexicalScope() func() {
+	saved := rt.scope.lexical
+	rt.scope.lexical = rt.newDeclarationStash(saved)
+	return func() {
+		rt.scope.lexical = saved
+	}
+}
+
+// cmplEvaluateNodeLexicalDeclaration creates let/const bindings in the current
+// lexical environment. There is no temporal dead zone: a binding read before
+// its declaration resolves to an outer scope rather than throwing.
+func (rt *runtime) cmplEvaluateNodeLexicalDeclaration(node *nodeLexicalDeclaration) Value {
+	for _, binding := range node.bindings {
+		value := Value{}
+		if binding.hasValue {
+			value = rt.cmplEvaluateNodeExpression(binding.initializer).resolve()
+		}
+		rt.declareLexicalBinding(binding.name, value, node.immutable)
+	}
+	return emptyValue
+}
+
+// declareLexicalBinding creates a single let/const binding in the current
+// lexical environment. When the environment is a declarative record (the usual
+// case for blocks, loops and lexical-scoped programs) const immutability is
+// enforced; otherwise it falls back to an ordinary binding.
+func (rt *runtime) declareLexicalBinding(name string, value Value, immutable bool) {
+	if ds, ok := rt.scope.lexical.(*dclStash); ok {
+		if immutable {
+			ds.createImmutableBinding(name, value)
+			return
+		}
+		if ds.hasBinding(name) {
+			ds.setBinding(name, value, false)
+		} else {
+			ds.createBinding(name, false, value)
+		}
+		return
+	}
+	rt.scope.lexical.setValue(name, value, false)
+}
+
 func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Value {
 	labels := append(rt.labels, "") //nolint:gocritic
 	rt.labels = nil
@@ -185,11 +243,25 @@ func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Valu
 	into := node.into
 	body := node.body
 
+	// A block-scoped loop variable (for (let k in obj)) gets a fresh binding
+	// per iteration in its own lexical environment.
+	lexical := node.lexicalBinding != ""
+	var outerLexical stasher
+	if lexical {
+		outerLexical = rt.scope.lexical
+		defer func() { rt.scope.lexical = outerLexical }()
+	}
+
 	result := emptyValue
 	obj := sourceObject
 	for obj != nil {
 		enumerateValue := emptyValue
 		obj.enumerate(false, func(name string) bool {
+			if lexical {
+				iterEnv := rt.newDeclarationStash(outerLexical)
+				iterEnv.createBinding(node.lexicalBinding, false, Value{})
+				rt.scope.lexical = iterEnv
+			}
 			into := rt.cmplEvaluateNodeExpression(into)
 			// In the case of: for (var abc in def) ...
 			if into.reference() == nil {
@@ -239,10 +311,35 @@ func (rt *runtime) cmplEvaluateNodeForStatement(node *nodeForStatement) Value {
 	update := node.update
 	body := node.body
 
+	// For block-scoped loop variables (for (let i ...)), each iteration runs in
+	// a fresh copy of the loop environment so that closures created in the body
+	// capture that iteration's bindings.
+	createPerIteration := func() {}
+	if len(node.lexicalBindings) > 0 {
+		outerLexical := rt.scope.lexical
+		loopEnv := rt.newDeclarationStash(outerLexical)
+		for _, name := range node.lexicalBindings {
+			loopEnv.createBinding(name, false, Value{})
+		}
+		rt.scope.lexical = loopEnv
+		defer func() { rt.scope.lexical = outerLexical }()
+
+		createPerIteration = func() {
+			prev := rt.scope.lexical.(*dclStash)
+			next := rt.newDeclarationStash(outerLexical)
+			for _, name := range node.lexicalBindings {
+				next.createBinding(name, false, prev.getBinding(name, false))
+			}
+			rt.scope.lexical = next
+		}
+	}
+
 	if initializer != nil {
 		initialResult := rt.cmplEvaluateNodeExpression(initializer)
 		initialResult.resolve() // Side-effect trigger
 	}
+
+	createPerIteration() // CreatePerIterationEnvironment, before the first test
 
 	result := emptyValue
 resultBreak:
@@ -283,6 +380,7 @@ resultBreak:
 			}
 		}
 	resultContinue:
+		createPerIteration() // copy the bindings forward for the next iteration
 		if update != nil {
 			updateResult := rt.cmplEvaluateNodeExpression(update)
 			updateResult.resolve() // Side-effect trigger

--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	goruntime "runtime"
 
+	"github.com/robertkrimen/otto/file"
 	"github.com/robertkrimen/otto/token"
 )
 
@@ -162,6 +163,102 @@ resultBreak:
 	return result
 }
 
+// bindMode selects what binding a destructuring pattern performs at each leaf.
+type bindMode int
+
+const (
+	bindAssign bindMode = iota // assign to an existing reference
+	bindLet                    // declare a new let binding
+	bindConst                  // declare a new const binding
+)
+
+// bindPattern binds a value against a destructuring target (an identifier, a
+// member reference, a nested pattern, or a target-with-default), using the
+// given mode at each leaf.
+func (rt *runtime) bindPattern(target nodeExpression, value Value, mode bindMode) {
+	switch t := target.(type) {
+	case *nodeIdentifier:
+		rt.bindName(t.name, value, mode, t.idx)
+	case *nodeDotExpression, *nodeBracketExpression:
+		// Only valid in assignment destructuring; assign to the member.
+		ref := rt.cmplEvaluateNodeExpression(target)
+		rt.putValue(ref.reference(), value)
+	case *nodeAssignExpression:
+		// target = default
+		if value.IsUndefined() {
+			value = rt.cmplEvaluateNodeExpression(t.right).resolve()
+		}
+		rt.bindPattern(t.left, value, mode)
+	case *nodeArrayPattern:
+		rt.bindArrayPattern(t, value, mode)
+	case *nodeObjectPattern:
+		rt.bindObjectPattern(t, value, mode)
+	default:
+		panic(rt.panicTypeError("invalid destructuring target %T", target))
+	}
+}
+
+func (rt *runtime) bindName(name string, value Value, mode bindMode, idx file.Idx) {
+	switch mode {
+	case bindLet:
+		rt.declareLexicalBinding(name, value, false)
+	case bindConst:
+		rt.declareLexicalBinding(name, value, true)
+	default: // bindAssign
+		ref := getIdentifierReference(rt, rt.scope.lexical, name, false, at(idx))
+		rt.putValue(ref, value)
+	}
+}
+
+func (rt *runtime) bindArrayPattern(pattern *nodeArrayPattern, value Value, mode bindMode) {
+	values := rt.spreadIterable(value)
+	for i, element := range pattern.elements {
+		if element == nil {
+			continue // elision (hole)
+		}
+		var elementValue Value
+		if i < len(values) {
+			elementValue = values[i]
+		}
+		rt.bindPattern(element, elementValue, mode)
+	}
+	if pattern.rest != nil {
+		rest := []Value{}
+		if len(pattern.elements) < len(values) {
+			rest = append(rest, values[len(pattern.elements):]...)
+		}
+		rt.bindPattern(pattern.rest, objectValue(rt.newArrayOf(rest)), mode)
+	}
+}
+
+func (rt *runtime) bindObjectPattern(pattern *nodeObjectPattern, value Value, mode bindMode) {
+	switch value.kind {
+	case valueUndefined, valueNull:
+		panic(rt.panicTypeError("cannot destructure %v", value))
+	}
+	obj := rt.toObject(value)
+
+	taken := map[string]bool{}
+	for _, prop := range pattern.properties {
+		key := prop.key
+		if prop.keyExpr != nil {
+			key = rt.cmplEvaluateNodeExpression(prop.keyExpr).resolve().string()
+		}
+		taken[key] = true
+		rt.bindPattern(prop.target, obj.get(key), mode)
+	}
+	if pattern.rest != nil {
+		rest := rt.newObject()
+		obj.enumerate(false, func(name string) bool {
+			if !taken[name] {
+				rest.put(name, obj.get(name), false)
+			}
+			return true
+		})
+		rt.bindPattern(pattern.rest, objectValue(rest), mode)
+	}
+}
+
 // cmplEvaluateNodeBlockStatement evaluates a block, introducing a fresh lexical
 // environment record when the block contains let/const declarations.
 func (rt *runtime) cmplEvaluateNodeBlockStatement(node *nodeBlockStatement) Value {
@@ -200,6 +297,14 @@ func (rt *runtime) cmplEvaluateNodeLexicalDeclaration(node *nodeLexicalDeclarati
 		value := Value{}
 		if binding.hasValue {
 			value = rt.cmplEvaluateNodeExpression(binding.initializer).resolve()
+		}
+		if binding.target != nil {
+			mode := bindLet
+			if node.immutable {
+				mode = bindConst
+			}
+			rt.bindPattern(binding.target, value, mode)
+			continue
 		}
 		rt.declareLexicalBinding(binding.name, value, node.immutable)
 	}
@@ -306,6 +411,39 @@ func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Valu
 	return result
 }
 
+// bindForTarget binds a loop value to a for-of/for-in loop target, which may be
+// a declared name, a destructuring pattern, or an existing assignment target.
+func (rt *runtime) bindForTarget(into nodeExpression, value Value, lexical, immutable bool) {
+	if ve, ok := into.(*nodeVariableExpression); ok {
+		if ve.target != nil {
+			mode := bindAssign
+			if lexical {
+				mode = bindLet
+				if immutable {
+					mode = bindConst
+				}
+			}
+			rt.bindPattern(ve.target, value, mode)
+			return
+		}
+		if lexical {
+			rt.declareLexicalBinding(ve.name, value, immutable)
+			return
+		}
+		ref := getIdentifierReference(rt, rt.scope.lexical, ve.name, false, at(ve.idx))
+		rt.putValue(ref, value)
+		return
+	}
+
+	// An existing identifier or member assignment target.
+	ref := rt.cmplEvaluateNodeExpression(into)
+	if ref.reference() == nil {
+		identifier := ref.string()
+		ref = toValue(getIdentifierReference(rt, rt.scope.lexical, identifier, false, -1))
+	}
+	rt.putValue(ref.reference(), value)
+}
+
 // cmplEvaluateNodeForOfStatement evaluates a for-of loop, iterating the values
 // of an iterable. Arrays, strings and array-like objects are supported. A
 // block-scoped loop variable (for (let x of ...)) gets a fresh binding per
@@ -324,7 +462,7 @@ func (rt *runtime) cmplEvaluateNodeForOfStatement(node *nodeForInStatement) Valu
 	into := node.into
 	body := node.body
 
-	lexical := node.lexicalBinding != ""
+	lexical := node.lexical
 	var outerLexical stasher
 	if lexical {
 		outerLexical = rt.scope.lexical
@@ -334,24 +472,11 @@ func (rt *runtime) cmplEvaluateNodeForOfStatement(node *nodeForInStatement) Valu
 	result := emptyValue
 forLoop:
 	for _, iterationValue := range values {
-		if lexical && node.immutable {
-			// A const binding is initialised directly with the iteration value.
-			iterEnv := rt.newDeclarationStash(outerLexical)
-			iterEnv.createImmutableBinding(node.lexicalBinding, iterationValue)
-			rt.scope.lexical = iterEnv
-		} else {
-			if lexical {
-				iterEnv := rt.newDeclarationStash(outerLexical)
-				iterEnv.createBinding(node.lexicalBinding, false, Value{})
-				rt.scope.lexical = iterEnv
-			}
-			ref := rt.cmplEvaluateNodeExpression(into)
-			if ref.reference() == nil {
-				identifier := ref.string()
-				ref = toValue(getIdentifierReference(rt, rt.scope.lexical, identifier, false, -1))
-			}
-			rt.putValue(ref.reference(), iterationValue)
+		if lexical {
+			// A fresh per-iteration environment for the loop binding(s).
+			rt.scope.lexical = rt.newDeclarationStash(outerLexical)
 		}
+		rt.bindForTarget(into, iterationValue, lexical, node.immutable)
 
 		for _, n := range body {
 			value := rt.cmplEvaluateNodeStatement(n)

--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -29,6 +29,9 @@ func (rt *runtime) cmplEvaluateNodeStatement(node nodeStatement) Value {
 	case *nodeLexicalDeclaration:
 		return rt.cmplEvaluateNodeLexicalDeclaration(node)
 
+	case *nodeClassStatement:
+		return rt.cmplEvaluateNodeClassStatement(node)
+
 	case *nodeBranchStatement:
 		target := node.label
 		switch node.branch { // FIXME Maybe node.kind? node.operator?

--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -230,6 +230,10 @@ func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Valu
 	labels := append(rt.labels, "") //nolint:gocritic
 	rt.labels = nil
 
+	if node.of {
+		return rt.cmplEvaluateNodeForOfStatement(node)
+	}
+
 	source := rt.cmplEvaluateNodeExpression(node.source)
 	sourceValue := source.resolve()
 
@@ -297,6 +301,74 @@ func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Valu
 		obj = obj.prototype
 		if !enumerateValue.isEmpty() {
 			result = enumerateValue
+		}
+	}
+	return result
+}
+
+// cmplEvaluateNodeForOfStatement evaluates a for-of loop, iterating the values
+// of an iterable. Arrays, strings and array-like objects are supported. A
+// block-scoped loop variable (for (let x of ...)) gets a fresh binding per
+// iteration.
+func (rt *runtime) cmplEvaluateNodeForOfStatement(node *nodeForInStatement) Value {
+	labels := append(rt.labels, "") //nolint:gocritic
+	rt.labels = nil
+
+	sourceValue := rt.cmplEvaluateNodeExpression(node.source).resolve()
+	switch sourceValue.kind {
+	case valueUndefined, valueNull:
+		panic(rt.panicTypeError("%v is not iterable", sourceValue))
+	}
+	values := rt.spreadIterable(sourceValue)
+
+	into := node.into
+	body := node.body
+
+	lexical := node.lexicalBinding != ""
+	var outerLexical stasher
+	if lexical {
+		outerLexical = rt.scope.lexical
+		defer func() { rt.scope.lexical = outerLexical }()
+	}
+
+	result := emptyValue
+forLoop:
+	for _, iterationValue := range values {
+		if lexical && node.immutable {
+			// A const binding is initialised directly with the iteration value.
+			iterEnv := rt.newDeclarationStash(outerLexical)
+			iterEnv.createImmutableBinding(node.lexicalBinding, iterationValue)
+			rt.scope.lexical = iterEnv
+		} else {
+			if lexical {
+				iterEnv := rt.newDeclarationStash(outerLexical)
+				iterEnv.createBinding(node.lexicalBinding, false, Value{})
+				rt.scope.lexical = iterEnv
+			}
+			ref := rt.cmplEvaluateNodeExpression(into)
+			if ref.reference() == nil {
+				identifier := ref.string()
+				ref = toValue(getIdentifierReference(rt, rt.scope.lexical, identifier, false, -1))
+			}
+			rt.putValue(ref.reference(), iterationValue)
+		}
+
+		for _, n := range body {
+			value := rt.cmplEvaluateNodeStatement(n)
+			switch value.kind {
+			case valueResult:
+				switch value.evaluateBreakContinue(labels) {
+				case resultReturn:
+					return value
+				case resultBreak:
+					break forLoop
+				case resultContinue:
+					continue forLoop
+				}
+			case valueEmpty:
+			default:
+				result = value
+			}
 		}
 	}
 	return result

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -109,6 +109,12 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 					out.parameterDefaults[i] = cmpl.parseExpression(def)
 				}
 			}
+			if expr.ParameterList.Targets != nil {
+				out.parameterTargets = make([]nodeExpression, len(list))
+				for i, target := range expr.ParameterList.Targets {
+					out.parameterTargets[i] = cmpl.parseExpression(target)
+				}
+			}
 			if expr.ParameterList.Rest != nil {
 				out.restParameter = expr.ParameterList.Rest.Name
 			}
@@ -645,6 +651,7 @@ type (
 		source            string
 		parameterList     []string
 		parameterDefaults []nodeExpression // parallel to parameterList; nil if none
+		parameterTargets  []nodeExpression // parallel to parameterList; pattern params
 		restParameter     string           // name of the rest parameter, or ""
 		varList           []string
 		functionList      []*nodeFunctionLiteral

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -103,6 +103,15 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 			for i, value := range list {
 				out.parameterList[i] = value.Name
 			}
+			if expr.ParameterList.Defaults != nil {
+				out.parameterDefaults = make([]nodeExpression, len(list))
+				for i, def := range expr.ParameterList.Defaults {
+					out.parameterDefaults[i] = cmpl.parseExpression(def)
+				}
+			}
+			if expr.ParameterList.Rest != nil {
+				out.restParameter = expr.ParameterList.Rest.Name
+			}
 		}
 		for _, value := range expr.DeclarationList {
 			switch value := value.(type) {
@@ -507,14 +516,16 @@ type (
 	}
 
 	nodeFunctionLiteral struct {
-		body          nodeStatement
-		file          *file.File
-		name          string
-		source        string
-		parameterList []string
-		varList       []string
-		functionList  []*nodeFunctionLiteral
-		isArrow       bool
+		body              nodeStatement
+		file              *file.File
+		name              string
+		source            string
+		parameterList     []string
+		parameterDefaults []nodeExpression // parallel to parameterList; nil if none
+		restParameter     string           // name of the rest parameter, or ""
+		varList           []string
+		functionList      []*nodeFunctionLiteral
+		isArrow           bool
 	}
 
 	nodeIdentifier struct {

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -204,6 +204,12 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 			value: cmpl.parseExpression(expr.Value),
 		}
 
+	case *ast.SuperExpression:
+		return &nodeSuperExpression{}
+
+	case *ast.ClassLiteral:
+		return cmpl.parseClassLiteral(expr)
+
 	case *ast.ArrayPattern:
 		out := &nodeArrayPattern{
 			elements: make([]nodeExpression, len(expr.Elements)),
@@ -262,15 +268,42 @@ func (cmpl *compiler) parseLoopBody(body ast.Statement) []nodeStatement {
 }
 
 // containsLexicalDeclaration reports whether the statement list directly
-// contains a let/const declaration, in which case the enclosing block needs a
-// lexical environment record.
+// contains a let/const or class declaration, in which case the enclosing block
+// needs a lexical environment record.
 func containsLexicalDeclaration(list []ast.Statement) bool {
 	for _, stmt := range list {
-		if _, ok := stmt.(*ast.LexicalDeclaration); ok {
+		switch stmt.(type) {
+		case *ast.LexicalDeclaration, *ast.ClassLiteral:
 			return true
 		}
 	}
 	return false
+}
+
+func classLiteralName(class *ast.ClassLiteral) string {
+	if class.Name != nil {
+		return class.Name.Name
+	}
+	return ""
+}
+
+func (cmpl *compiler) parseClassLiteral(expr *ast.ClassLiteral) *nodeClassLiteral {
+	out := &nodeClassLiteral{
+		name:       classLiteralName(expr),
+		superClass: cmpl.parseExpression(expr.SuperClass),
+		source:     expr.Source,
+		elements:   make([]nodeClassElement, len(expr.Body)),
+	}
+	for i, element := range expr.Body {
+		out.elements[i] = nodeClassElement{
+			kind:    element.Kind,
+			static:  element.Static,
+			key:     element.Key,
+			keyExpr: cmpl.parseExpression(element.KeyExpression),
+			method:  cmpl.parseExpression(element.Method).(*nodeFunctionLiteral),
+		}
+	}
+	return out
 }
 
 // astPatternNames returns all identifier names bound by a destructuring
@@ -338,6 +371,12 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 			out.list[i] = cmpl.parseStatement(value)
 		}
 		return out
+
+	case *ast.ClassLiteral:
+		return &nodeClassStatement{
+			name:  classLiteralName(stmt),
+			class: cmpl.parseClassLiteral(stmt),
+		}
 
 	case *ast.LexicalDeclaration:
 		out := &nodeLexicalDeclaration{
@@ -643,6 +682,23 @@ type (
 		rest     nodeExpression
 	}
 
+	nodeSuperExpression struct{}
+
+	nodeClassLiteral struct {
+		name       string
+		superClass nodeExpression
+		elements   []nodeClassElement
+		source     string
+	}
+
+	nodeClassElement struct {
+		kind    string // "method", "get", "set", "constructor"
+		static  bool
+		key     string
+		keyExpr nodeExpression
+		method  *nodeFunctionLiteral
+	}
+
 	nodeObjectPattern struct {
 		properties []nodeObjectPatternProperty
 		rest       nodeExpression
@@ -689,6 +745,11 @@ type (
 	nodeLexicalDeclaration struct {
 		bindings  []nodeLexicalBinding
 		immutable bool // const
+	}
+
+	nodeClassStatement struct {
+		name  string
+		class *nodeClassLiteral
 	}
 
 	nodeLexicalBinding struct {
@@ -809,6 +870,8 @@ func (*nodeSequenceExpression) expressionNode()    {}
 func (*nodeSpreadExpression) expressionNode()      {}
 func (*nodeArrayPattern) expressionNode()          {}
 func (*nodeObjectPattern) expressionNode()         {}
+func (*nodeSuperExpression) expressionNode()       {}
+func (*nodeClassLiteral) expressionNode()          {}
 func (*nodeTemplateLiteral) expressionNode()       {}
 func (*nodeThisExpression) expressionNode()        {}
 func (*nodeUnaryExpression) expressionNode()       {}
@@ -829,6 +892,7 @@ func (*nodeForStatement) statementNode()        {}
 func (*nodeIfStatement) statementNode()         {}
 func (*nodeLabelledStatement) statementNode()   {}
 func (*nodeLexicalDeclaration) statementNode()  {}
+func (*nodeClassStatement) statementNode()      {}
 func (*nodeReturnStatement) statementNode()     {}
 func (*nodeSwitchStatement) statementNode()     {}
 func (*nodeThrowStatement) statementNode()      {}

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -119,7 +119,11 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 				out.functionList = append(out.functionList, cmpl.parseExpression(value.Function).(*nodeFunctionLiteral))
 			case *ast.VariableDeclaration:
 				for _, value := range value.List {
-					out.varList = append(out.varList, value.Name)
+					if value.Target != nil {
+						out.varList = append(out.varList, astPatternNames(value.Target)...)
+					} else {
+						out.varList = append(out.varList, value.Name)
+					}
 				}
 			default:
 				panic(fmt.Sprintf("parse expression unknown function declaration type %T", value))
@@ -200,6 +204,30 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 			value: cmpl.parseExpression(expr.Value),
 		}
 
+	case *ast.ArrayPattern:
+		out := &nodeArrayPattern{
+			elements: make([]nodeExpression, len(expr.Elements)),
+			rest:     cmpl.parseExpression(expr.Rest),
+		}
+		for i, element := range expr.Elements {
+			out.elements[i] = cmpl.parseExpression(element)
+		}
+		return out
+
+	case *ast.ObjectPattern:
+		out := &nodeObjectPattern{
+			properties: make([]nodeObjectPatternProperty, len(expr.Properties)),
+			rest:       cmpl.parseExpression(expr.Rest),
+		}
+		for i, prop := range expr.Properties {
+			out.properties[i] = nodeObjectPatternProperty{
+				key:     prop.Key,
+				keyExpr: cmpl.parseExpression(prop.KeyExpression),
+				target:  cmpl.parseExpression(prop.Target),
+			}
+		}
+		return out
+
 	case *ast.ThisExpression:
 		return &nodeThisExpression{}
 
@@ -215,6 +243,7 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 			idx:         expr.Idx0(),
 			name:        expr.Name,
 			initializer: cmpl.parseExpression(expr.Initializer),
+			target:      cmpl.parseExpression(expr.Target),
 		}
 	default:
 		panic(fmt.Errorf("parse expression unknown node type %T", expr))
@@ -242,6 +271,39 @@ func containsLexicalDeclaration(list []ast.Statement) bool {
 		}
 	}
 	return false
+}
+
+// astPatternNames returns all identifier names bound by a destructuring
+// binding pattern, used to hoist var-declared pattern bindings.
+func astPatternNames(target ast.Expression) []string {
+	var names []string
+	var walk func(ast.Expression)
+	walk = func(e ast.Expression) {
+		switch t := e.(type) {
+		case *ast.Identifier:
+			names = append(names, t.Name)
+		case *ast.AssignExpression:
+			walk(t.Left)
+		case *ast.ArrayPattern:
+			for _, element := range t.Elements {
+				if element != nil {
+					walk(element)
+				}
+			}
+			if t.Rest != nil {
+				walk(t.Rest)
+			}
+		case *ast.ObjectPattern:
+			for _, prop := range t.Properties {
+				walk(prop.Target)
+			}
+			if t.Rest != nil {
+				walk(t.Rest)
+			}
+		}
+	}
+	walk(target)
+	return names
 }
 
 // lexicalBindingNames extracts the names declared by a for-loop's lexical
@@ -284,7 +346,10 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 		}
 		for i, value := range stmt.List {
 			ve := value.(*ast.VariableExpression)
-			binding := nodeLexicalBinding{name: ve.Name}
+			binding := nodeLexicalBinding{
+				name:   ve.Name,
+				target: cmpl.parseExpression(ve.Target),
+			}
 			if ve.Initializer != nil {
 				binding.initializer = cmpl.parseExpression(ve.Initializer)
 				binding.hasValue = true
@@ -327,6 +392,7 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 		}
 		out.of = stmt.Of
 		if stmt.Lexical != 0 {
+			out.lexical = true
 			out.immutable = stmt.Lexical == token.CONST
 			if ve, ok := stmt.Into.(*ast.VariableExpression); ok {
 				out.lexicalBinding = ve.Name
@@ -572,6 +638,22 @@ type (
 		value nodeExpression
 	}
 
+	nodeArrayPattern struct {
+		elements []nodeExpression // nil entry = elision (hole)
+		rest     nodeExpression
+	}
+
+	nodeObjectPattern struct {
+		properties []nodeObjectPatternProperty
+		rest       nodeExpression
+	}
+
+	nodeObjectPatternProperty struct {
+		key     string
+		keyExpr nodeExpression
+		target  nodeExpression
+	}
+
 	nodeTemplateLiteral struct {
 		strings     []string
 		expressions []nodeExpression
@@ -589,6 +671,7 @@ type (
 		initializer nodeExpression
 		name        string
 		idx         file.Idx
+		target      nodeExpression // destructuring pattern, when name is empty
 	}
 )
 
@@ -612,6 +695,7 @@ type (
 		name        string
 		initializer nodeExpression
 		hasValue    bool
+		target      nodeExpression // destructuring pattern, when name is empty
 	}
 
 	nodeBranchStatement struct {
@@ -647,8 +731,9 @@ type (
 		source         nodeExpression
 		body           []nodeStatement
 		lexicalBinding string // name of a let/const loop binding, if any
-		immutable      bool
-		of             bool // for-of (iterate values) rather than for-in (keys)
+		lexical        bool   // the loop variable is a let/const binding
+		immutable      bool   // const loop variable
+		of             bool   // for-of (iterate values) rather than for-in (keys)
 	}
 
 	nodeForStatement struct {
@@ -722,6 +807,8 @@ func (*nodeObjectLiteral) expressionNode()         {}
 func (*nodeRegExpLiteral) expressionNode()         {}
 func (*nodeSequenceExpression) expressionNode()    {}
 func (*nodeSpreadExpression) expressionNode()      {}
+func (*nodeArrayPattern) expressionNode()          {}
+func (*nodeObjectPattern) expressionNode()         {}
 func (*nodeTemplateLiteral) expressionNode()       {}
 func (*nodeThisExpression) expressionNode()        {}
 func (*nodeUnaryExpression) expressionNode()       {}

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -678,9 +678,9 @@ type (
 
 	nodeProperty struct {
 		value         nodeExpression
+		keyExpression nodeExpression
 		key           string
 		kind          string
-		keyExpression nodeExpression
 	}
 
 	nodeRegExpLiteral struct {
@@ -697,36 +697,36 @@ type (
 	}
 
 	nodeArrayPattern struct {
-		elements []nodeExpression // nil entry = elision (hole)
 		rest     nodeExpression
+		elements []nodeExpression
 	}
 
 	nodeSuperExpression struct{}
 
 	nodeClassLiteral struct {
-		name       string
 		superClass nodeExpression
-		elements   []nodeClassElement
+		name       string
 		source     string
+		elements   []nodeClassElement
 	}
 
 	nodeClassElement struct {
-		kind    string // "method", "get", "set", "constructor"
-		static  bool
-		key     string
 		keyExpr nodeExpression
 		method  *nodeFunctionLiteral
+		kind    string
+		key     string
+		static  bool
 	}
 
 	nodeObjectPattern struct {
-		properties []nodeObjectPatternProperty
 		rest       nodeExpression
+		properties []nodeObjectPatternProperty
 	}
 
 	nodeObjectPatternProperty struct {
-		key     string
 		keyExpr nodeExpression
 		target  nodeExpression
+		key     string
 	}
 
 	nodeTaggedTemplate struct {
@@ -751,9 +751,9 @@ type (
 
 	nodeVariableExpression struct {
 		initializer nodeExpression
+		target      nodeExpression
 		name        string
 		idx         file.Idx
-		target      nodeExpression // destructuring pattern, when name is empty
 	}
 )
 
@@ -774,15 +774,15 @@ type (
 	}
 
 	nodeClassStatement struct {
-		name  string
 		class *nodeClassLiteral
+		name  string
 	}
 
 	nodeLexicalBinding struct {
-		name        string
 		initializer nodeExpression
+		target      nodeExpression
+		name        string
 		hasValue    bool
-		target      nodeExpression // destructuring pattern, when name is empty
 	}
 
 	nodeBranchStatement struct {
@@ -816,11 +816,11 @@ type (
 	nodeForInStatement struct {
 		into           nodeExpression
 		source         nodeExpression
+		lexicalBinding string
 		body           []nodeStatement
-		lexicalBinding string // name of a let/const loop binding, if any
-		lexical        bool   // the loop variable is a let/const binding
-		immutable      bool   // const loop variable
-		of             bool   // for-of (iterate values) rather than for-in (keys)
+		lexical        bool
+		immutable      bool
+		of             bool
 	}
 
 	nodeForStatement struct {

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -148,9 +148,10 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 		}
 		for i, value := range expr.Value {
 			out.value[i] = nodeProperty{
-				key:   value.Key,
-				kind:  value.Kind,
-				value: cmpl.parseExpression(value.Value),
+				key:           value.Key,
+				kind:          value.Kind,
+				value:         cmpl.parseExpression(value.Value),
+				keyExpression: cmpl.parseExpression(value.KeyExpression),
 			}
 		}
 		return out
@@ -486,9 +487,10 @@ type (
 	}
 
 	nodeProperty struct {
-		value nodeExpression
-		key   string
-		kind  string
+		value         nodeExpression
+		key           string
+		kind          string
+		keyExpression nodeExpression
 	}
 
 	nodeRegExpLiteral struct {

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -207,6 +207,46 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 	}
 }
 
+// parseLoopBody compiles a loop body, flattening a plain block into its
+// statement list (as before) but preserving a block that introduces lexical
+// (let/const) declarations so that each iteration gets a fresh environment.
+func (cmpl *compiler) parseLoopBody(body ast.Statement) []nodeStatement {
+	node := cmpl.parseStatement(body)
+	if block, ok := node.(*nodeBlockStatement); ok && !block.lexical {
+		return block.list
+	}
+	return []nodeStatement{node}
+}
+
+// containsLexicalDeclaration reports whether the statement list directly
+// contains a let/const declaration, in which case the enclosing block needs a
+// lexical environment record.
+func containsLexicalDeclaration(list []ast.Statement) bool {
+	for _, stmt := range list {
+		if _, ok := stmt.(*ast.LexicalDeclaration); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// lexicalBindingNames extracts the names declared by a for-loop's lexical
+// initializer (a sequence of variable expressions).
+func lexicalBindingNames(initializer ast.Expression) []string {
+	var names []string
+	switch init := initializer.(type) {
+	case *ast.SequenceExpression:
+		for _, item := range init.Sequence {
+			if ve, ok := item.(*ast.VariableExpression); ok {
+				names = append(names, ve.Name)
+			}
+		}
+	case *ast.VariableExpression:
+		names = append(names, init.Name)
+	}
+	return names
+}
+
 func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 	if stmt == nil {
 		return nil
@@ -215,10 +255,27 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 	switch stmt := stmt.(type) {
 	case *ast.BlockStatement:
 		out := &nodeBlockStatement{
-			list: make([]nodeStatement, len(stmt.List)),
+			list:    make([]nodeStatement, len(stmt.List)),
+			lexical: containsLexicalDeclaration(stmt.List),
 		}
 		for i, value := range stmt.List {
 			out.list[i] = cmpl.parseStatement(value)
+		}
+		return out
+
+	case *ast.LexicalDeclaration:
+		out := &nodeLexicalDeclaration{
+			immutable: stmt.Token == token.CONST,
+			bindings:  make([]nodeLexicalBinding, len(stmt.List)),
+		}
+		for i, value := range stmt.List {
+			ve := value.(*ast.VariableExpression)
+			binding := nodeLexicalBinding{name: ve.Name}
+			if ve.Initializer != nil {
+				binding.initializer = cmpl.parseExpression(ve.Initializer)
+				binding.hasValue = true
+			}
+			out.bindings[i] = binding
 		}
 		return out
 
@@ -238,12 +295,7 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 		out := &nodeDoWhileStatement{
 			test: cmpl.parseExpression(stmt.Test),
 		}
-		body := cmpl.parseStatement(stmt.Body)
-		if block, ok := body.(*nodeBlockStatement); ok {
-			out.body = block.list
-		} else {
-			out.body = append(out.body, body)
-		}
+		out.body = cmpl.parseLoopBody(stmt.Body)
 		return out
 
 	case *ast.EmptyStatement:
@@ -259,12 +311,13 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 			into:   cmpl.parseExpression(stmt.Into),
 			source: cmpl.parseExpression(stmt.Source),
 		}
-		body := cmpl.parseStatement(stmt.Body)
-		if block, ok := body.(*nodeBlockStatement); ok {
-			out.body = block.list
-		} else {
-			out.body = append(out.body, body)
+		if stmt.Lexical != 0 {
+			out.immutable = stmt.Lexical == token.CONST
+			if ve, ok := stmt.Into.(*ast.VariableExpression); ok {
+				out.lexicalBinding = ve.Name
+			}
 		}
+		out.body = cmpl.parseLoopBody(stmt.Body)
 		return out
 
 	case *ast.ForStatement:
@@ -273,12 +326,11 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 			update:      cmpl.parseExpression(stmt.Update),
 			test:        cmpl.parseExpression(stmt.Test),
 		}
-		body := cmpl.parseStatement(stmt.Body)
-		if block, ok := body.(*nodeBlockStatement); ok {
-			out.body = block.list
-		} else {
-			out.body = append(out.body, body)
+		if stmt.Lexical != 0 {
+			out.lexicalBindings = lexicalBindingNames(stmt.Initializer)
+			out.immutable = stmt.Lexical == token.CONST
 		}
+		out.body = cmpl.parseLoopBody(stmt.Body)
 		return out
 
 	case *ast.FunctionStatement:
@@ -350,12 +402,7 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 		out := &nodeWhileStatement{
 			test: cmpl.parseExpression(stmt.Test),
 		}
-		body := cmpl.parseStatement(stmt.Body)
-		if block, ok := body.(*nodeBlockStatement); ok {
-			out.body = block.list
-		} else {
-			out.body = append(out.body, body)
-		}
+		out.body = cmpl.parseLoopBody(stmt.Body)
 		return out
 
 	case *ast.WithStatement:
@@ -381,8 +428,9 @@ func cmplParse(in *ast.Program) *nodeProgram {
 
 func (cmpl *compiler) parse() *nodeProgram {
 	out := &nodeProgram{
-		body: make([]nodeStatement, len(cmpl.program.Body)),
-		file: cmpl.program.File,
+		body:    make([]nodeStatement, len(cmpl.program.Body)),
+		file:    cmpl.program.File,
+		lexical: containsLexicalDeclaration(cmpl.program.Body),
 	}
 	for i, value := range cmpl.program.Body {
 		out.body[i] = cmpl.parseStatement(value)
@@ -407,6 +455,7 @@ type nodeProgram struct {
 	body         []nodeStatement
 	varList      []string
 	functionList []*nodeFunctionLiteral
+	lexical      bool // contains top-level let/const declarations
 }
 
 type node interface{}
@@ -529,7 +578,19 @@ type (
 	}
 
 	nodeBlockStatement struct {
-		list []nodeStatement
+		list    []nodeStatement
+		lexical bool // contains let/const declarations at the block's top level
+	}
+
+	nodeLexicalDeclaration struct {
+		bindings  []nodeLexicalBinding
+		immutable bool // const
+	}
+
+	nodeLexicalBinding struct {
+		name        string
+		initializer nodeExpression
+		hasValue    bool
 	}
 
 	nodeBranchStatement struct {
@@ -561,16 +622,20 @@ type (
 	}
 
 	nodeForInStatement struct {
-		into   nodeExpression
-		source nodeExpression
-		body   []nodeStatement
+		into           nodeExpression
+		source         nodeExpression
+		body           []nodeStatement
+		lexicalBinding string // name of a let/const loop binding, if any
+		immutable      bool
 	}
 
 	nodeForStatement struct {
-		initializer nodeExpression
-		update      nodeExpression
-		test        nodeExpression
-		body        []nodeStatement
+		initializer     nodeExpression
+		update          nodeExpression
+		test            nodeExpression
+		body            []nodeStatement
+		lexicalBindings []string // let/const loop binding names, if any
+		immutable       bool
 	}
 
 	nodeIfStatement struct {
@@ -653,6 +718,7 @@ func (*nodeForInStatement) statementNode()      {}
 func (*nodeForStatement) statementNode()        {}
 func (*nodeIfStatement) statementNode()         {}
 func (*nodeLabelledStatement) statementNode()   {}
+func (*nodeLexicalDeclaration) statementNode()  {}
 func (*nodeReturnStatement) statementNode()     {}
 func (*nodeSwitchStatement) statementNode()     {}
 func (*nodeThrowStatement) statementNode()      {}

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -195,6 +195,11 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 		}
 		return out
 
+	case *ast.SpreadExpression:
+		return &nodeSpreadExpression{
+			value: cmpl.parseExpression(expr.Value),
+		}
+
 	case *ast.ThisExpression:
 		return &nodeThisExpression{}
 
@@ -562,6 +567,10 @@ type (
 		sequence []nodeExpression
 	}
 
+	nodeSpreadExpression struct {
+		value nodeExpression
+	}
+
 	nodeTemplateLiteral struct {
 		strings     []string
 		expressions []nodeExpression
@@ -710,6 +719,7 @@ func (*nodeNewExpression) expressionNode()         {}
 func (*nodeObjectLiteral) expressionNode()         {}
 func (*nodeRegExpLiteral) expressionNode()         {}
 func (*nodeSequenceExpression) expressionNode()    {}
+func (*nodeSpreadExpression) expressionNode()      {}
 func (*nodeTemplateLiteral) expressionNode()       {}
 func (*nodeThisExpression) expressionNode()        {}
 func (*nodeUnaryExpression) expressionNode()       {}

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -175,6 +175,16 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 			value: stringValue(expr.Value),
 		}
 
+	case *ast.TemplateLiteral:
+		out := &nodeTemplateLiteral{
+			strings:     expr.Strings,
+			expressions: make([]nodeExpression, len(expr.Expressions)),
+		}
+		for i, value := range expr.Expressions {
+			out.expressions[i] = cmpl.parseExpression(value)
+		}
+		return out
+
 	case *ast.ThisExpression:
 		return &nodeThisExpression{}
 
@@ -490,6 +500,11 @@ type (
 		sequence []nodeExpression
 	}
 
+	nodeTemplateLiteral struct {
+		strings     []string
+		expressions []nodeExpression
+	}
+
 	nodeThisExpression struct{}
 
 	nodeUnaryExpression struct {
@@ -617,6 +632,7 @@ func (*nodeNewExpression) expressionNode()         {}
 func (*nodeObjectLiteral) expressionNode()         {}
 func (*nodeRegExpLiteral) expressionNode()         {}
 func (*nodeSequenceExpression) expressionNode()    {}
+func (*nodeTemplateLiteral) expressionNode()       {}
 func (*nodeThisExpression) expressionNode()        {}
 func (*nodeUnaryExpression) expressionNode()       {}
 func (*nodeVariableExpression) expressionNode()    {}

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -91,10 +91,11 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 			name = expr.Name.Name
 		}
 		out := &nodeFunctionLiteral{
-			name:   name,
-			body:   cmpl.parseStatement(expr.Body),
-			source: expr.Source,
-			file:   cmpl.file,
+			name:    name,
+			body:    cmpl.parseStatement(expr.Body),
+			source:  expr.Source,
+			file:    cmpl.file,
+			isArrow: expr.IsArrow,
 		}
 		if expr.ParameterList != nil {
 			list := expr.ParameterList.List
@@ -453,6 +454,7 @@ type (
 		parameterList []string
 		varList       []string
 		functionList  []*nodeFunctionLiteral
+		isArrow       bool
 	}
 
 	nodeIdentifier struct {

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -207,6 +207,18 @@ func (cmpl *compiler) parseExpression(expr ast.Expression) nodeExpression {
 	case *ast.SuperExpression:
 		return &nodeSuperExpression{}
 
+	case *ast.TaggedTemplateExpression:
+		out := &nodeTaggedTemplate{
+			tag:         cmpl.parseExpression(expr.Tag),
+			quasis:      expr.Template.Strings,
+			raw:         expr.Template.Raw,
+			expressions: make([]nodeExpression, len(expr.Template.Expressions)),
+		}
+		for i, value := range expr.Template.Expressions {
+			out.expressions[i] = cmpl.parseExpression(value)
+		}
+		return out
+
 	case *ast.ClassLiteral:
 		return cmpl.parseClassLiteral(expr)
 
@@ -710,6 +722,13 @@ type (
 		target  nodeExpression
 	}
 
+	nodeTaggedTemplate struct {
+		tag         nodeExpression
+		quasis      []string
+		raw         []string
+		expressions []nodeExpression
+	}
+
 	nodeTemplateLiteral struct {
 		strings     []string
 		expressions []nodeExpression
@@ -868,6 +887,7 @@ func (*nodeObjectLiteral) expressionNode()         {}
 func (*nodeRegExpLiteral) expressionNode()         {}
 func (*nodeSequenceExpression) expressionNode()    {}
 func (*nodeSpreadExpression) expressionNode()      {}
+func (*nodeTaggedTemplate) expressionNode()        {}
 func (*nodeArrayPattern) expressionNode()          {}
 func (*nodeObjectPattern) expressionNode()         {}
 func (*nodeSuperExpression) expressionNode()       {}

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -325,6 +325,7 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 			into:   cmpl.parseExpression(stmt.Into),
 			source: cmpl.parseExpression(stmt.Source),
 		}
+		out.of = stmt.Of
 		if stmt.Lexical != 0 {
 			out.immutable = stmt.Lexical == token.CONST
 			if ve, ok := stmt.Into.(*ast.VariableExpression); ok {
@@ -647,6 +648,7 @@ type (
 		body           []nodeStatement
 		lexicalBinding string // name of a let/const loop binding, if any
 		immutable      bool
+		of             bool // for-of (iterate values) rather than for-in (keys)
 	}
 
 	nodeForStatement struct {

--- a/default_params_test.go
+++ b/default_params_test.go
@@ -1,0 +1,52 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestDefaultParameters(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// A default is used when the argument is omitted.
+		test(`
+            function f(a, b = 2) { return a + b; }
+            f(1);
+        `, 3)
+
+		// An explicitly passed value overrides the default.
+		test(`
+            function f(a, b = 2) { return a + b; }
+            f(1, 10);
+        `, 11)
+
+		// Passing undefined triggers the default; other falsy values do not.
+		test(`
+            function f(a, b = 2) { return a + b; }
+            [f(1, undefined), f(1, 0)].join(",");
+        `, "3,1")
+
+		// Defaults may reference earlier parameters.
+		test(`
+            function f(a = 1, b = a + 1) { return a + "/" + b; }
+            f();
+        `, "1/2")
+
+		test(`
+            function f(a = 1, b = a * 2) { return b; }
+            f(5);
+        `, 10)
+
+		// A default in the middle of the list.
+		test(`
+            function f(a, b = 2, c = 3) { return a + b + c; }
+            f(1, undefined, 10);
+        `, 13)
+
+		// Method shorthand with a default.
+		test(`
+            var o = { m(x = 7) { return x; } };
+            o.m();
+        `, 7)
+	})
+}

--- a/destructuring_test.go
+++ b/destructuring_test.go
@@ -1,0 +1,100 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestArrayDestructuring(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`let [a, b] = [1, 2]; a + "," + b;`, "1,2")
+
+		// Elisions (holes).
+		test(`let [a, , c] = [1, 2, 3]; a + "," + c;`, "1,3")
+
+		// Rest element.
+		test(`let [a, ...rest] = [1, 2, 3, 4]; a + "/" + rest.join(",");`, "1/2,3,4")
+
+		// Defaults.
+		test(`let [a = 10, b = 20] = [1]; a + "," + b;`, "1,20")
+
+		// Nested.
+		test(`let [[a], [b]] = [[1], [2]]; a + "," + b;`, "1,2")
+
+		// Destructuring a string.
+		test(`let [a, b] = "hi"; a + b;`, "hi")
+
+		// From a function result.
+		test(`
+            function f() { return [1, 2, 3]; }
+            let [x, y, z] = f();
+            x + y + z;
+        `, 6)
+
+		// var destructuring.
+		test(`var [a, b] = [8, 9]; a + b;`, 17)
+	})
+}
+
+func TestObjectDestructuring(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`let {x, y} = {x: 1, y: 2}; x + "," + y;`, "1,2")
+
+		// Renaming.
+		test(`let {a: p, b: q} = {a: 5, b: 6}; p + "," + q;`, "5,6")
+
+		// Defaults.
+		test(`let {x = 7} = {}; x;`, 7)
+		test(`let {a: x = 7} = {}; x;`, 7)
+
+		// Nested.
+		test(`let {a: {b}} = {a: {b: 42}}; b;`, 42)
+		test(`let {a: {b: {c}}} = {a: {b: {c: "deep"}}}; c;`, "deep")
+
+		// Computed key.
+		test(`let k = "dyn"; let {[k]: v} = {dyn: 5}; v;`, 5)
+
+		// Object rest.
+		test(`let {a, ...rest} = {a: 1, b: 2, c: 3}; a + "/" + rest.b + "/" + rest.c;`, "1/2/3")
+	})
+}
+
+func TestDestructuringAssignment(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Assignment (not declaration) destructuring.
+		test(`var a, b; [a, b] = [3, 4]; a + "," + b;`, "3,4")
+
+		// Assigning into a member.
+		test(`
+            var o = {};
+            ({x: o.k} = {x: 99});
+            o.k;
+        `, 99)
+
+		// Swap idiom.
+		test(`var a = 1, b = 2; [a, b] = [b, a]; a + "," + b;`, "2,1")
+	})
+}
+
+func TestDestructuringForOf(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var out = [];
+            for (const [k, v] of [["a", 1], ["b", 2]]) out.push(k + "=" + v);
+            out.join(",");
+        `, "a=1,b=2")
+
+		test(`
+            var s = 0;
+            for (let {x} of [{x: 1}, {x: 2}, {x: 3}]) s += x;
+            s;
+        `, 6)
+	})
+}

--- a/for_of_test.go
+++ b/for_of_test.go
@@ -1,0 +1,68 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestForOf(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Iterating an array yields its values, not its indices.
+		test(`
+            var s = 0;
+            for (var x of [1, 2, 3]) s += x;
+            s;
+        `, 6)
+
+		// for (let ...) of.
+		test(`
+            var s = 0;
+            for (let x of [10, 20]) s += x;
+            s;
+        `, 30)
+
+		// Iterating a string yields its characters.
+		test(`
+            var r = "";
+            for (const c of "abc") r += c + ".";
+            r;
+        `, "a.b.c.")
+
+		// const loop variable.
+		test(`
+            var sum = 0;
+            for (const n of [1, 2, 3, 4]) sum += n;
+            sum;
+        `, 10)
+	})
+}
+
+func TestForOfControlFlow(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var out = [];
+            for (let x of [1, 2, 3, 4]) {
+                if (x === 2) continue;
+                if (x === 4) break;
+                out.push(x);
+            }
+            out.join(",");
+        `, "1,3")
+	})
+}
+
+func TestForOfPerIteration(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Each iteration of for (let ... of) has its own binding.
+		test(`
+            var fns = [];
+            for (let x of [1, 2, 3]) fns.push(function() { return x; });
+            [fns[0](), fns[1](), fns[2]()].join(",");
+        `, "1,2,3")
+	})
+}

--- a/inline.go
+++ b/inline.go
@@ -3026,11 +3026,49 @@ func (rt *runtime) newContext() {
 					},
 				},
 			},
+			"raw": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "raw",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "raw",
+							call: builtinStringRaw,
+						},
+					},
+				},
+			},
 		},
 		propertyOrder: []string{
 			propertyLength,
 			propertyPrototype,
 			"fromCharCode",
+			"raw",
 		},
 	}
 

--- a/lexical_test.go
+++ b/lexical_test.go
@@ -1,0 +1,140 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestLetConstBasic(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`let x = 1; x;`, 1)
+		test(`const y = 2; y;`, 2)
+		test(`let a = 1, b = 2; a + b;`, 3)
+		test(`let u; typeof u;`, "undefined")
+
+		// const reassignment throws a TypeError.
+		test(`raise:
+            const c = 1;
+            c = 2;
+        `, "TypeError: Assignment to constant variable.")
+	})
+}
+
+func TestLetConstBlockScope(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// An inner block does not leak its binding.
+		test(`
+            let a = 1;
+            { let a = 2; }
+            a;
+        `, 1)
+
+		// A binding declared in a block is not visible outside it.
+		test(`
+            { let b = 5; }
+            typeof b;
+        `, "undefined")
+
+		// Nested shadowing.
+		test(`
+            let n = 1;
+            { let n = 2; { let n = 3; } }
+            n;
+        `, 1)
+
+		// const is block scoped too.
+		test(`
+            const k = 10;
+            { const k = 20; }
+            k;
+        `, 10)
+	})
+}
+
+func TestLetPerIterationBinding(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// The classic case: each iteration of a for (let ...) loop has its own
+		// binding, so closures capture distinct values.
+		test(`
+            var fns = [];
+            for (let i = 0; i < 3; i++) {
+                fns.push(function() { return i; });
+            }
+            [fns[0](), fns[1](), fns[2]()].join(",");
+        `, "0,1,2")
+
+		// A var-declared loop variable is shared across iterations.
+		test(`
+            var fns = [];
+            for (var j = 0; j < 3; j++) {
+                fns.push(function() { return j; });
+            }
+            [fns[0](), fns[2]()].join(",");
+        `, "3,3")
+
+		// A let in the loop body is fresh each iteration.
+		test(`
+            var fns = [];
+            for (let i = 0; i < 3; i++) {
+                let doubled = i * 10;
+                fns.push(function() { return doubled; });
+            }
+            [fns[0](), fns[1](), fns[2]()].join(",");
+        `, "0,10,20")
+
+		// Sum still works (mutation across iterations behaves normally).
+		test(`
+            let total = 0;
+            for (let i = 0; i <= 4; i++) total += i;
+            total;
+        `, 10)
+	})
+}
+
+func TestLetForIn(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var keys = [];
+            var o = { a: 1, b: 2 };
+            for (let p in o) keys.push(p);
+            keys.sort().join(",");
+        `, "a,b")
+
+		// Each iteration's binding is independent.
+		test(`
+            var fns = [];
+            for (let p in { x: 1, y: 1 }) {
+                fns.push(function() { return p; });
+            }
+            fns.length;
+        `, 2)
+	})
+}
+
+func TestLetInFunctionAndWhile(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            function f() { let z = 42; return z; }
+            f();
+        `, 42)
+
+		test(`
+            let total = 0, c = 0;
+            while (c < 3) {
+                let step = c * 2;
+                total += step;
+                c++;
+            }
+            total;
+        `, 6)
+	})
+}

--- a/object_es6_test.go
+++ b/object_es6_test.go
@@ -1,0 +1,101 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestObjectShorthand(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Property shorthand: { x, y } is sugar for { x: x, y: y }.
+		test(`
+            var x = 1, y = 2;
+            var o = { x, y };
+            [o.x, o.y].join(",");
+        `, "1,2")
+
+		// Shorthand mixed with ordinary properties.
+		test(`
+            var a = 10;
+            var o = { a, b: 20 };
+            [o.a, o.b].join(",");
+        `, "10,20")
+
+		// Properties literally named "get" and "set".
+		test(`
+            var o = { get: 1, set: 2 };
+            [o.get, o.set].join(",");
+        `, "1,2")
+	})
+}
+
+func TestObjectMethodShorthand(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var o = { foo() { return 42; } };
+            o.foo();
+        `, 42)
+
+		test(`
+            var o = { add(a, b) { return a + b; } };
+            o.add(3, 4);
+        `, 7)
+
+		// A method shorthand can use `this`.
+		test(`
+            var o = { value: 5, get() { return this.value; } };
+            o.get();
+        `, 5)
+	})
+}
+
+func TestObjectComputedProperty(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var k = "dyn";
+            var o = { [k]: 9 };
+            o.dyn;
+        `, 9)
+
+		test(`
+            var o = { ["a" + "b"]: 5 };
+            o.ab;
+        `, 5)
+
+		// Computed keys are evaluated in order.
+		test(`
+            var i = 0;
+            var o = { [++i]: "a", [++i]: "b" };
+            o[1] + o[2];
+        `, "ab")
+
+		// A computed method key.
+		test(`
+            var name = "run";
+            var o = { [name]() { return "ok"; } };
+            o.run();
+        `, "ok")
+	})
+}
+
+func TestObjectAccessorsStillWork(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Ensure getters/setters continue to parse alongside the new forms.
+		test(`
+            var store = 0;
+            var o = {
+                get x() { return store; },
+                set x(v) { store = v; },
+            };
+            o.x = 11;
+            o.x;
+        `, 11)
+	})
+}

--- a/param_destructuring_test.go
+++ b/param_destructuring_test.go
@@ -1,0 +1,74 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestObjectParameterDestructuring(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            function f({a, b}) { return a + b; }
+            f({a: 1, b: 2});
+        `, 3)
+
+		// Default within an object pattern parameter.
+		test(`
+            function f({a, b = 10}) { return a + b; }
+            f({a: 5});
+        `, 15)
+
+		// Nested object pattern.
+		test(`
+            function f({a: {b}}) { return b; }
+            f({a: {b: 42}});
+        `, 42)
+
+		// A defaulted object-pattern parameter.
+		test(`
+            function f({a = 1, b = 2} = {}) { return a + "/" + b; }
+            f();
+        `, "1/2")
+
+		// Mixed plain and pattern parameters.
+		test(`
+            function f(x, {y, z}) { return x + y + z; }
+            f(1, {y: 2, z: 3});
+        `, 6)
+	})
+}
+
+func TestArrayParameterDestructuring(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            function f([x, y]) { return x * y; }
+            f([3, 4]);
+        `, 12)
+
+		// Rest within an array pattern parameter.
+		test(`
+            function f([a, ...rest]) { return a + "/" + rest.join(","); }
+            f([1, 2, 3]);
+        `, "1/2,3")
+	})
+}
+
+func TestArrowParameterDestructuring(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`var g = ({x, y}) => x + y; g({x: 7, y: 8});`, 15)
+		test(`var h = ([a, b]) => a + "-" + b; h(["p", "q"]);`, "p-q")
+
+		// Cover grammar: defaulted object pattern in an arrow parameter.
+		test(`var k = ({n = 3} = {}) => n; [k(), k({n: 9})].join(",");`, "3,9")
+
+		// A destructuring callback, the common real-world use.
+		test(`
+            [{a: 1, b: 2}, {a: 3, b: 4}].map(({a, b}) => a + b).join(",");
+        `, "3,7")
+	})
+}

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -409,6 +409,24 @@ func (p *parser) parseRegExpLiteral() *ast.RegExpLiteral {
 }
 
 func (p *parser) parseVariableDeclaration(declarationList *[]*ast.VariableExpression) ast.Expression {
+	// Destructuring binding: var/let/const [a, b] = ... or { a, b } = ...
+	if p.token == token.LEFT_BRACKET || p.token == token.LEFT_BRACE {
+		idx := p.idx
+		target := p.parseBindingTarget()
+		node := &ast.VariableExpression{
+			Idx:    idx,
+			Target: target,
+		}
+		if declarationList != nil {
+			*declarationList = append(*declarationList, node)
+		}
+		if p.token == token.ASSIGN {
+			p.next()
+			node.Initializer = p.parseAssignmentExpression()
+		}
+		return node
+	}
+
 	if p.token != token.IDENTIFIER {
 		idx := p.expect(token.IDENTIFIER)
 		p.nextStatement()
@@ -439,6 +457,177 @@ func (p *parser) parseVariableDeclaration(declarationList *[]*ast.VariableExpres
 	}
 
 	return node
+}
+
+// literalToPattern reinterprets an array or object literal that appears on the
+// left of a destructuring assignment as a binding pattern. It returns false if
+// the literal cannot be a valid assignment pattern.
+func literalToPattern(expr ast.Expression) (ast.Expression, bool) {
+	switch lit := expr.(type) {
+	case *ast.ArrayLiteral:
+		pattern := &ast.ArrayPattern{LeftBracket: lit.LeftBracket, RightBracket: lit.RightBracket}
+		for _, element := range lit.Value {
+			switch el := element.(type) {
+			case *ast.EmptyExpression:
+				pattern.Elements = append(pattern.Elements, nil)
+			case *ast.SpreadExpression:
+				target, ok := assignmentTarget(el.Value)
+				if !ok {
+					return nil, false
+				}
+				pattern.Rest = target
+			default:
+				target, ok := assignmentTarget(element)
+				if !ok {
+					return nil, false
+				}
+				pattern.Elements = append(pattern.Elements, target)
+			}
+		}
+		return pattern, true
+	case *ast.ObjectLiteral:
+		pattern := &ast.ObjectPattern{LeftBrace: lit.LeftBrace, RightBrace: lit.RightBrace}
+		for _, prop := range lit.Value {
+			if prop.Kind != "value" {
+				return nil, false
+			}
+			target, ok := assignmentTarget(prop.Value)
+			if !ok {
+				return nil, false
+			}
+			pattern.Properties = append(pattern.Properties, &ast.PatternProperty{
+				Key:           prop.Key,
+				KeyExpression: prop.KeyExpression,
+				Target:        target,
+			})
+		}
+		return pattern, true
+	}
+	return nil, false
+}
+
+// assignmentTarget validates and, where necessary, converts a single
+// destructuring assignment target. Identifiers and member expressions are
+// valid targets; nested literals become nested patterns; an AssignExpression
+// (target = default) keeps its shape with its left side converted.
+func assignmentTarget(expr ast.Expression) (ast.Expression, bool) {
+	switch e := expr.(type) {
+	case *ast.Identifier, *ast.DotExpression, *ast.BracketExpression:
+		return expr, true
+	case *ast.ArrayLiteral, *ast.ObjectLiteral:
+		return literalToPattern(expr)
+	case *ast.AssignExpression:
+		if e.Operator != token.ASSIGN {
+			return nil, false
+		}
+		left, ok := assignmentTarget(e.Left)
+		if !ok {
+			return nil, false
+		}
+		e.Left = left
+		return e, true
+	}
+	return nil, false
+}
+
+// parseBindingTarget parses a binding target: a plain identifier or a
+// destructuring pattern.
+func (p *parser) parseBindingTarget() ast.Expression {
+	switch p.token {
+	case token.LEFT_BRACKET:
+		return p.parseArrayBindingPattern()
+	case token.LEFT_BRACE:
+		return p.parseObjectBindingPattern()
+	case token.IDENTIFIER:
+		return p.parseIdentifier()
+	default:
+		idx := p.expect(token.IDENTIFIER)
+		return &ast.BadExpression{From: idx, To: p.idx}
+	}
+}
+
+// parseBindingTargetWithDefault parses a binding target optionally followed by
+// "= default", representing the default as an AssignExpression.
+func (p *parser) parseBindingTargetWithDefault() ast.Expression {
+	target := p.parseBindingTarget()
+	if p.token == token.ASSIGN {
+		p.next()
+		return &ast.AssignExpression{
+			Operator: token.ASSIGN,
+			Left:     target,
+			Right:    p.parseAssignmentExpression(),
+		}
+	}
+	return target
+}
+
+func (p *parser) parseArrayBindingPattern() ast.Expression {
+	opening := p.expect(token.LEFT_BRACKET)
+	pattern := &ast.ArrayPattern{LeftBracket: opening}
+	for p.token != token.RIGHT_BRACKET && p.token != token.EOF {
+		if p.token == token.COMMA {
+			pattern.Elements = append(pattern.Elements, nil) // elision
+			p.next()
+			continue
+		}
+		if p.token == token.ELLIPSIS {
+			p.next()
+			pattern.Rest = p.parseBindingTarget()
+			break
+		}
+		pattern.Elements = append(pattern.Elements, p.parseBindingTargetWithDefault())
+		if p.token != token.RIGHT_BRACKET {
+			p.expect(token.COMMA)
+		}
+	}
+	pattern.RightBracket = p.expect(token.RIGHT_BRACKET)
+	return pattern
+}
+
+func (p *parser) parseObjectBindingPattern() ast.Expression {
+	opening := p.expect(token.LEFT_BRACE)
+	pattern := &ast.ObjectPattern{LeftBrace: opening}
+	for p.token != token.RIGHT_BRACE && p.token != token.EOF {
+		if p.token == token.ELLIPSIS {
+			p.next()
+			pattern.Rest = p.parseBindingTarget()
+			break
+		}
+
+		prop := &ast.PatternProperty{}
+		if p.token == token.LEFT_BRACKET {
+			keyExpr, _ := p.parseComputedPropertyKey()
+			prop.KeyExpression = keyExpr
+			p.expect(token.COLON)
+			prop.Target = p.parseBindingTargetWithDefault()
+		} else {
+			keyIdx := p.idx
+			_, key := p.parseObjectPropertyKey()
+			prop.Key = key
+			if p.token == token.COLON {
+				p.next()
+				prop.Target = p.parseBindingTargetWithDefault()
+			} else {
+				// Shorthand: { a } or { a = default }.
+				var target ast.Expression = &ast.Identifier{Name: key, Idx: keyIdx}
+				if p.token == token.ASSIGN {
+					p.next()
+					target = &ast.AssignExpression{
+						Operator: token.ASSIGN,
+						Left:     target,
+						Right:    p.parseAssignmentExpression(),
+					}
+				}
+				prop.Target = target
+			}
+		}
+		pattern.Properties = append(pattern.Properties, prop)
+		if p.token != token.RIGHT_BRACE {
+			p.expect(token.COMMA)
+		}
+	}
+	pattern.RightBrace = p.expect(token.RIGHT_BRACE)
+	return pattern
 }
 
 func (p *parser) parseVariableDeclarationList(idx file.Idx) []ast.Expression {
@@ -1270,6 +1459,20 @@ func (p *parser) parseAssignmentExpression() ast.Expression {
 		p.next()
 		switch left.(type) {
 		case *ast.Identifier, *ast.DotExpression, *ast.BracketExpression:
+		case *ast.ArrayLiteral, *ast.ObjectLiteral:
+			// Destructuring assignment: reinterpret the literal as a pattern.
+			if operator != token.ASSIGN {
+				p.error(left.Idx0(), "invalid left-hand side in assignment")
+				p.nextStatement()
+				return &ast.BadExpression{From: idx, To: p.idx}
+			}
+			if pattern, ok := literalToPattern(left); ok {
+				left = pattern
+			} else {
+				p.error(left.Idx0(), "invalid destructuring assignment target")
+				p.nextStatement()
+				return &ast.BadExpression{From: idx, To: p.idx}
+			}
 		default:
 			p.error(left.Idx0(), "invalid left-hand side in assignment")
 			p.nextStatement()

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -137,6 +137,11 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 		}
 	case token.FUNCTION:
 		return p.parseFunction(false)
+	case token.CLASS:
+		return p.parseClass(false)
+	case token.SUPER:
+		p.next()
+		return &ast.SuperExpression{Idx: idx}
 	}
 
 	p.errorUnexpectedToken(p.token)

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -48,7 +48,11 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 			Idx:  idx,
 		}
 		if p.token == token.ARROW {
-			return p.parseArrowFunction(idx, []*ast.Identifier{identifier}, idx, identifier.Idx1())
+			return p.parseArrowFunction(idx, &ast.ParameterList{
+				List:    []*ast.Identifier{identifier},
+				Opening: idx,
+				Closing: identifier.Idx1(),
+			})
 		}
 		return identifier
 	case token.NULL:
@@ -111,7 +115,7 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 			// syntax error (an empty parenthesised expression).
 			closing := p.expect(token.RIGHT_PARENTHESIS)
 			if p.token == token.ARROW {
-				return p.parseArrowFunction(opening, nil, opening, closing)
+				return p.parseArrowFunction(opening, &ast.ParameterList{Opening: opening, Closing: closing})
 			}
 			p.error(opening, "Unexpected token )")
 			return &ast.BadExpression{From: opening, To: closing}
@@ -122,12 +126,12 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 		}
 		closing := p.expect(token.RIGHT_PARENTHESIS)
 		if p.token == token.ARROW {
-			list, ok := arrowParameterList(expression)
+			params, ok := arrowParameterList(expression, opening, closing)
 			if !ok {
 				p.error(expression.Idx0(), "malformed arrow function parameter list")
 				return &ast.BadExpression{From: opening, To: p.idx}
 			}
-			return p.parseArrowFunction(opening, list, opening, closing)
+			return p.parseArrowFunction(opening, params)
 		}
 		return expression
 	case token.THIS:
@@ -770,6 +774,22 @@ func (p *parser) parseObjectProperty() ast.Property {
 			Key:   value,
 			Kind:  "value",
 			Value: &ast.Identifier{Name: value, Idx: keyIdx},
+		}
+	}
+
+	// CoverInitializedName: { foo = default }. Only valid when the object
+	// literal is later reinterpreted as a destructuring pattern; retained here
+	// so the arrow-function cover grammar can parse ({ a = 1 }) => ...
+	if p.token == token.ASSIGN {
+		p.next()
+		return ast.Property{
+			Key:  value,
+			Kind: "value",
+			Value: &ast.AssignExpression{
+				Operator: token.ASSIGN,
+				Left:     &ast.Identifier{Name: value, Idx: keyIdx},
+				Right:    p.parseAssignmentExpression(),
+			},
 		}
 	}
 

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -660,7 +660,12 @@ func (p *parser) parseArrayLiteral() ast.Expression {
 			continue
 		}
 
-		exp := p.parseAssignmentExpression()
+		var exp ast.Expression
+		if p.token == token.ELLIPSIS {
+			exp = p.parseSpreadElement()
+		} else {
+			exp = p.parseAssignmentExpression()
+		}
 
 		value = append(value, exp)
 		if p.token != token.RIGHT_BRACKET {
@@ -682,13 +687,27 @@ func (p *parser) parseArrayLiteral() ast.Expression {
 	}
 }
 
+// parseSpreadElement parses a ...expr spread element.
+func (p *parser) parseSpreadElement() ast.Expression {
+	idx := p.expect(token.ELLIPSIS)
+	return &ast.SpreadExpression{
+		Idx:   idx,
+		Value: p.parseAssignmentExpression(),
+	}
+}
+
 func (p *parser) parseArgumentList() (argumentList []ast.Expression, idx0, idx1 file.Idx) { //nolint:nonamedreturns
 	if p.mode&StoreComments != 0 {
 		p.comments.Unset()
 	}
 	idx0 = p.expect(token.LEFT_PARENTHESIS)
 	for p.token != token.RIGHT_PARENTHESIS {
-		exp := p.parseAssignmentExpression()
+		var exp ast.Expression
+		if p.token == token.ELLIPSIS {
+			exp = p.parseSpreadElement()
+		} else {
+			exp = p.parseAssignmentExpression()
+		}
 		if p.mode&StoreComments != 0 {
 			p.comments.SetExpression(exp)
 		}

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -169,6 +169,7 @@ func (p *parser) parseTemplateLiteral(idx file.Idx, literal string) ast.Expressi
 	}
 
 	var cooked strings.Builder
+	rawStart := 0
 	i := 0
 	for i < len(inner) {
 		switch {
@@ -176,6 +177,7 @@ func (p *parser) parseTemplateLiteral(idx file.Idx, literal string) ast.Expressi
 			i = cookTemplateEscape(&cooked, inner, i+1)
 		case inner[i] == '$' && i+1 < len(inner) && inner[i+1] == '{':
 			node.Strings = append(node.Strings, cooked.String())
+			node.Raw = append(node.Raw, inner[rawStart:i])
 			cooked.Reset()
 			src, next, err := extractTemplateSubstitution(inner, i+2)
 			if err != nil {
@@ -184,12 +186,14 @@ func (p *parser) parseTemplateLiteral(idx file.Idx, literal string) ast.Expressi
 			}
 			node.Expressions = append(node.Expressions, p.parseTemplateExpression(src, idx))
 			i = next
+			rawStart = next
 		default:
 			cooked.WriteByte(inner[i])
 			i++
 		}
 	}
 	node.Strings = append(node.Strings, cooked.String())
+	node.Raw = append(node.Raw, inner[rawStart:])
 
 	return node
 }
@@ -1014,9 +1018,26 @@ func (p *parser) parseLeftHandSideExpression() ast.Expression {
 			left = p.parseDotMember(left)
 		case token.LEFT_BRACKET:
 			left = p.parseBracketMember(left)
+		case token.TEMPLATE:
+			left = p.parseTaggedTemplate(left)
 		default:
 			return left
 		}
+	}
+}
+
+// parseTaggedTemplate wraps a tag expression and the template literal that
+// immediately follows it.
+func (p *parser) parseTaggedTemplate(tag ast.Expression) ast.Expression {
+	idx := p.idx
+	literal := p.literal
+	template, ok := p.parseTemplateLiteral(idx, literal).(*ast.TemplateLiteral)
+	if !ok {
+		return &ast.BadExpression{From: tag.Idx0(), To: p.idx}
+	}
+	return &ast.TaggedTemplateExpression{
+		Tag:      tag,
+		Template: template,
 	}
 }
 
@@ -1059,6 +1080,8 @@ func (p *parser) parseLeftHandSideExpressionAllowCall() ast.Expression {
 			left = p.parseBracketMember(left)
 		case token.LEFT_PARENTHESIS:
 			left = p.parseCallExpression(left)
+		case token.TEMPLATE:
+			left = p.parseTaggedTemplate(left)
 		default:
 			return left
 		}

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -502,11 +502,50 @@ func (p *parser) parseObjectPropertyKey() (string, string) {
 	return literal, value
 }
 
+// isAccessorKey reports whether, having just read a "get" or "set" key, the
+// current token begins an accessor's property name rather than turning "get" /
+// "set" into an ordinary property (get:), shorthand (get, / get}) or a method
+// named get/set (get(). The property name itself may be an identifier, string,
+// number or a keyword such as null, so this is expressed as a negative check.
+func (p *parser) isAccessorKey() bool {
+	switch p.token {
+	case token.COLON, token.COMMA, token.RIGHT_BRACE, token.LEFT_PARENTHESIS:
+		return false
+	default:
+		return true
+	}
+}
+
 func (p *parser) parseObjectProperty() ast.Property {
+	// Computed property key: [expr]: value, or [expr]() { ... }.
+	if p.token == token.LEFT_BRACKET {
+		keyExpr, keyIdx := p.parseComputedPropertyKey()
+		if p.token == token.LEFT_PARENTHESIS {
+			return p.parseMethodDefinition(keyIdx, "", keyExpr)
+		}
+		if p.mode&StoreComments != 0 {
+			p.comments.MarkComments(ast.COLON)
+		}
+		p.expect(token.COLON)
+		return ast.Property{
+			KeyExpression: keyExpr,
+			Kind:          "value",
+			Value:         p.parseAssignmentExpression(),
+		}
+	}
+
+	keyIdx := p.idx
 	literal, value := p.parseObjectPropertyKey()
-	if literal == "get" && p.token != token.COLON {
+
+	// Getter / setter: get foo() { ... } or set foo(v) { ... }.
+	if (literal == "get" || literal == "set") && p.isAccessorKey() {
 		idx := p.idx
-		_, value = p.parseObjectPropertyKey()
+		var keyExpr ast.Expression
+		if p.token == token.LEFT_BRACKET {
+			keyExpr, _ = p.parseComputedPropertyKey()
+		} else {
+			_, value = p.parseObjectPropertyKey()
+		}
 		parameterList := p.parseFunctionParameterList()
 
 		node := &ast.FunctionLiteral{
@@ -515,24 +554,24 @@ func (p *parser) parseObjectProperty() ast.Property {
 		}
 		p.parseFunctionBlock(node)
 		return ast.Property{
-			Key:   value,
-			Kind:  "get",
-			Value: node,
+			Key:           value,
+			KeyExpression: keyExpr,
+			Kind:          literal,
+			Value:         node,
 		}
-	} else if literal == "set" && p.token != token.COLON {
-		idx := p.idx
-		_, value = p.parseObjectPropertyKey()
-		parameterList := p.parseFunctionParameterList()
+	}
 
-		node := &ast.FunctionLiteral{
-			Function:      idx,
-			ParameterList: parameterList,
-		}
-		p.parseFunctionBlock(node)
+	// Method shorthand: foo() { ... }.
+	if p.token == token.LEFT_PARENTHESIS {
+		return p.parseMethodDefinition(keyIdx, value, nil)
+	}
+
+	// Property shorthand: { foo } is sugar for { foo: foo }.
+	if p.token == token.COMMA || p.token == token.RIGHT_BRACE {
 		return ast.Property{
 			Key:   value,
-			Kind:  "set",
-			Value: node,
+			Kind:  "value",
+			Value: &ast.Identifier{Name: value, Idx: keyIdx},
 		}
 	}
 
@@ -551,6 +590,32 @@ func (p *parser) parseObjectProperty() ast.Property {
 		p.comments.SetExpression(exp.Value)
 	}
 	return exp
+}
+
+// parseComputedPropertyKey parses a [expr] computed key, returning the
+// expression and the index of the opening bracket.
+func (p *parser) parseComputedPropertyKey() (ast.Expression, file.Idx) {
+	idx := p.expect(token.LEFT_BRACKET)
+	keyExpr := p.parseAssignmentExpression()
+	p.expect(token.RIGHT_BRACKET)
+	return keyExpr, idx
+}
+
+// parseMethodDefinition parses the "(params) { body }" of an object method
+// shorthand, returning a "value" property whose value is a function literal.
+func (p *parser) parseMethodDefinition(idx file.Idx, key string, keyExpr ast.Expression) ast.Property {
+	parameterList := p.parseFunctionParameterList()
+	node := &ast.FunctionLiteral{
+		Function:      idx,
+		ParameterList: parameterList,
+	}
+	p.parseFunctionBlock(node)
+	return ast.Property{
+		Key:           key,
+		KeyExpression: keyExpr,
+		Kind:          "value",
+		Value:         node,
+	}
 }
 
 func (p *parser) parseObjectLiteral() ast.Expression {

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -41,10 +41,14 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 				}
 			}
 		}
-		return &ast.Identifier{
+		identifier := &ast.Identifier{
 			Name: literal,
 			Idx:  idx,
 		}
+		if p.token == token.ARROW {
+			return p.parseArrowFunction(idx, []*ast.Identifier{identifier}, idx, identifier.Idx1())
+		}
+		return identifier
 	case token.NULL:
 		p.next()
 		return &ast.NullLiteral{
@@ -97,12 +101,30 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 	case token.LEFT_BRACKET:
 		return p.parseArrayLiteral()
 	case token.LEFT_PARENTHESIS:
-		p.expect(token.LEFT_PARENTHESIS)
+		opening := p.expect(token.LEFT_PARENTHESIS)
+		if p.token == token.RIGHT_PARENTHESIS {
+			// Either an empty arrow parameter list, "() => ...", or a
+			// syntax error (an empty parenthesised expression).
+			closing := p.expect(token.RIGHT_PARENTHESIS)
+			if p.token == token.ARROW {
+				return p.parseArrowFunction(opening, nil, opening, closing)
+			}
+			p.error(opening, "Unexpected token )")
+			return &ast.BadExpression{From: opening, To: closing}
+		}
 		expression := p.parseExpression()
 		if p.mode&StoreComments != 0 {
 			p.comments.Unset()
 		}
-		p.expect(token.RIGHT_PARENTHESIS)
+		closing := p.expect(token.RIGHT_PARENTHESIS)
+		if p.token == token.ARROW {
+			list, ok := arrowParameterList(expression)
+			if !ok {
+				p.error(expression.Idx0(), "malformed arrow function parameter list")
+				return &ast.BadExpression{From: opening, To: p.idx}
+			}
+			return p.parseArrowFunction(opening, list, opening, closing)
+		}
 		return expression
 	case token.THIS:
 		p.next()

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/robertkrimen/otto/ast"
 	"github.com/robertkrimen/otto/file"
@@ -82,6 +84,8 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 			Literal: literal,
 			Value:   value,
 		}
+	case token.TEMPLATE:
+		return p.parseTemplateLiteral(idx, literal)
 	case token.NUMBER:
 		p.next()
 		value, err := parseNumberLiteral(literal)
@@ -138,6 +142,218 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 	p.errorUnexpectedToken(p.token)
 	p.nextStatement()
 	return &ast.BadExpression{From: idx, To: p.idx}
+}
+
+// parseTemplateLiteral builds a TemplateLiteral node from the raw template
+// source (including the enclosing backticks). It splits the literal into cooked
+// string segments and embedded ${ ... } expressions, parsing each embedded
+// expression with a sub-parser.
+func (p *parser) parseTemplateLiteral(idx file.Idx, literal string) ast.Expression {
+	closeQuote := file.Idx(int(idx) + len(literal) - 1)
+	p.next()
+
+	node := &ast.TemplateLiteral{
+		OpenQuote:  idx,
+		CloseQuote: closeQuote,
+	}
+
+	// Strip the enclosing backticks.
+	inner := ""
+	if len(literal) >= 2 {
+		inner = literal[1 : len(literal)-1]
+	}
+
+	var cooked strings.Builder
+	i := 0
+	for i < len(inner) {
+		switch {
+		case inner[i] == '\\':
+			i = cookTemplateEscape(&cooked, inner, i+1)
+		case inner[i] == '$' && i+1 < len(inner) && inner[i+1] == '{':
+			node.Strings = append(node.Strings, cooked.String())
+			cooked.Reset()
+			src, next, err := extractTemplateSubstitution(inner, i+2)
+			if err != nil {
+				p.error(idx, err.Error())
+				return &ast.BadExpression{From: idx, To: closeQuote}
+			}
+			node.Expressions = append(node.Expressions, p.parseTemplateExpression(src, idx))
+			i = next
+		default:
+			cooked.WriteByte(inner[i])
+			i++
+		}
+	}
+	node.Strings = append(node.Strings, cooked.String())
+
+	return node
+}
+
+// parseTemplateExpression parses the source of a single ${ ... } substitution
+// into an expression using a sub-parser.
+func (p *parser) parseTemplateExpression(src string, idx file.Idx) ast.Expression {
+	if strings.TrimSpace(src) == "" {
+		p.error(idx, "unexpected token in template literal")
+		return &ast.BadExpression{From: idx, To: idx}
+	}
+
+	program, err := ParseFile(nil, "", "("+src+"\n)", 0)
+	if err != nil {
+		p.error(idx, "invalid template substitution: %s", err.Error())
+		return &ast.BadExpression{From: idx, To: idx}
+	}
+
+	stmt, ok := program.Body[0].(*ast.ExpressionStatement)
+	if !ok || stmt.Expression == nil {
+		p.error(idx, "invalid template substitution")
+		return &ast.BadExpression{From: idx, To: idx}
+	}
+
+	return stmt.Expression
+}
+
+// extractTemplateSubstitution returns the source of a ${ ... } substitution
+// beginning at start (just past the opening brace) and the index just past its
+// matching closing brace. Nested braces, string literals and nested template
+// literals are skipped so their contents do not terminate the substitution.
+func extractTemplateSubstitution(s string, start int) (string, int, error) {
+	depth := 1
+	i := start
+	for i < len(s) {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start:i], i + 1, nil
+			}
+		case '\\':
+			i++ // skip the escaped character
+		case '`':
+			j, err := skipNestedTemplate(s, i+1)
+			if err != nil {
+				return "", 0, err
+			}
+			i = j
+			continue
+		case '\'', '"':
+			j, err := skipNestedString(s, i)
+			if err != nil {
+				return "", 0, err
+			}
+			i = j
+			continue
+		}
+		i++
+	}
+	return "", 0, errInvalidTemplate
+}
+
+// skipNestedTemplate returns the index just past the closing backtick of a
+// template literal whose body begins at i.
+func skipNestedTemplate(s string, i int) (int, error) {
+	for i < len(s) {
+		switch s[i] {
+		case '`':
+			return i + 1, nil
+		case '\\':
+			i++
+		case '$':
+			if i+1 < len(s) && s[i+1] == '{' {
+				j, err := extractNestedSubstitution(s, i+2)
+				if err != nil {
+					return 0, err
+				}
+				i = j
+				continue
+			}
+		}
+		i++
+	}
+	return 0, errInvalidTemplate
+}
+
+// extractNestedSubstitution is like extractTemplateSubstitution but returns
+// only the index past the closing brace.
+func extractNestedSubstitution(s string, start int) (int, error) {
+	_, next, err := extractTemplateSubstitution(s, start)
+	return next, err
+}
+
+// skipNestedString returns the index just past the closing quote of a string
+// literal whose opening quote is at i.
+func skipNestedString(s string, i int) (int, error) {
+	quote := s[i]
+	i++
+	for i < len(s) {
+		switch s[i] {
+		case quote:
+			return i + 1, nil
+		case '\\':
+			i++
+		}
+		i++
+	}
+	return 0, errInvalidTemplate
+}
+
+// cookTemplateEscape interprets the escape sequence whose character follows the
+// backslash at s[i], writing the cooked result to b, and returns the index just
+// past the consumed escape.
+func cookTemplateEscape(b *strings.Builder, s string, i int) int {
+	if i >= len(s) {
+		return i
+	}
+	switch c := s[i]; c {
+	case 'n':
+		b.WriteByte('\n')
+	case 'r':
+		b.WriteByte('\r')
+	case 't':
+		b.WriteByte('\t')
+	case 'b':
+		b.WriteByte('\b')
+	case 'f':
+		b.WriteByte('\f')
+	case 'v':
+		b.WriteByte('\v')
+	case '0':
+		b.WriteByte(0)
+	case 'x':
+		if i+3 <= len(s) {
+			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 32); err == nil {
+				b.WriteRune(rune(v))
+				return i + 3
+			}
+		}
+		b.WriteByte(c)
+	case 'u':
+		if i+1 < len(s) && s[i+1] == '{' {
+			if end := strings.IndexByte(s[i+2:], '}'); end >= 0 {
+				if v, err := strconv.ParseUint(s[i+2:i+2+end], 16, 32); err == nil {
+					b.WriteRune(rune(v))
+					return i + 2 + end + 1
+				}
+			}
+		} else if i+5 <= len(s) {
+			if v, err := strconv.ParseUint(s[i+1:i+5], 16, 32); err == nil {
+				b.WriteRune(rune(v))
+				return i + 5
+			}
+		}
+		b.WriteByte(c)
+	case '\n':
+		return i + 1 // line continuation
+	case '\r':
+		if i+1 < len(s) && s[i+1] == '\n' {
+			return i + 2
+		}
+		return i + 1
+	default:
+		b.WriteByte(c)
+	}
+	return i + 1
 }
 
 func (p *parser) parseRegExpLiteral() *ast.RegExpLiteral {

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -311,10 +311,15 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 			case '>':
 				tkn = p.switch6(token.GREATER, token.GREATER_OR_EQUAL, '>', token.SHIFT_RIGHT, token.SHIFT_RIGHT_ASSIGN, '>', token.UNSIGNED_SHIFT_RIGHT, token.UNSIGNED_SHIFT_RIGHT_ASSIGN)
 			case '=':
-				tkn = p.switch2(token.ASSIGN, token.EQUAL)
-				if tkn == token.EQUAL && p.chr == '=' {
+				if p.chr == '>' {
 					p.read()
-					tkn = token.STRICT_EQUAL
+					tkn = token.ARROW
+				} else {
+					tkn = p.switch2(token.ASSIGN, token.EQUAL)
+					if tkn == token.EQUAL && p.chr == '=' {
+						p.read()
+						tkn = token.STRICT_EQUAL
+					}
 				}
 			case '!':
 				tkn = p.switch2(token.NOT, token.NOT_EQUAL)

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -242,10 +242,11 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 			case ':':
 				tkn = token.COLON
 			case '.':
-				if digitValue(p.chr) < 10 {
+				switch {
+				case digitValue(p.chr) < 10:
 					insertSemicolon = true
 					tkn, literal = p.scanNumericLiteral(true)
-				} else if p.chr == '.' {
+				case p.chr == '.':
 					// Could be the ... (ellipsis) of rest/spread syntax.
 					p.read() // second dot
 					if p.chr == '.' {
@@ -255,7 +256,7 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 						p.errorUnexpected(idx, '.')
 						tkn = token.ILLEGAL
 					}
-				} else {
+				default:
 					tkn = token.PERIOD
 				}
 			case ',':
@@ -659,7 +660,7 @@ newline:
 }
 
 // errInvalidTemplate is returned when a template literal is malformed.
-var errInvalidTemplate = errors.New("Unterminated template literal")
+var errInvalidTemplate = errors.New("unterminated template literal")
 
 // scanTemplate scans a template literal, beginning just after the opening
 // backtick, and returns its raw source including the enclosing backticks.
@@ -669,7 +670,7 @@ func (p *parser) scanTemplate(offset int) (string, error) {
 	for p.chr != '`' {
 		switch p.chr {
 		case -1:
-			return "", errors.New("Unterminated template literal")
+			return "", errors.New("unterminated template literal")
 		case '\\':
 			p.read() // backslash
 			if p.chr >= 0 {
@@ -701,7 +702,7 @@ func (p *parser) scanTemplateSubstitution() error {
 	for depth > 0 {
 		switch p.chr {
 		case -1:
-			return errors.New("Unterminated template literal")
+			return errors.New("unterminated template literal")
 		case '{':
 			depth++
 			p.read()
@@ -736,7 +737,7 @@ func (p *parser) skipStringLiteral(quote rune) error {
 	for p.chr != quote {
 		switch {
 		case p.chr < 0, p.chr == '\n', p.chr == '\r':
-			return errors.New("String not terminated")
+			return errors.New("string not terminated")
 		case p.chr == '\\':
 			p.read()
 			if p.chr >= 0 {

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -245,6 +245,16 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 				if digitValue(p.chr) < 10 {
 					insertSemicolon = true
 					tkn, literal = p.scanNumericLiteral(true)
+				} else if p.chr == '.' {
+					// Could be the ... (ellipsis) of rest/spread syntax.
+					p.read() // second dot
+					if p.chr == '.' {
+						p.read() // third dot
+						tkn = token.ELLIPSIS
+					} else {
+						p.errorUnexpected(idx, '.')
+						tkn = token.ILLEGAL
+					}
 				} else {
 					tkn = token.PERIOD
 				}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -348,6 +348,15 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 				if err != nil {
 					tkn = token.ILLEGAL
 				}
+			case '`':
+				insertSemicolon = true
+				tkn = token.TEMPLATE
+				var err error
+				literal, err = p.scanTemplate(p.chrOffset - 1)
+				if err != nil {
+					p.error(idx, err.Error())
+					tkn = token.ILLEGAL
+				}
 			default:
 				p.errorUnexpected(idx, chr)
 				tkn = token.ILLEGAL
@@ -637,6 +646,98 @@ newline:
 		p.error(p.idxOf(offset), err)
 	}
 	return "", errors.New(err)
+}
+
+// errInvalidTemplate is returned when a template literal is malformed.
+var errInvalidTemplate = errors.New("Unterminated template literal")
+
+// scanTemplate scans a template literal, beginning just after the opening
+// backtick, and returns its raw source including the enclosing backticks.
+// Substitutions (${ ... }) are scanned but not interpreted here; the parser
+// later splits the raw literal into cooked strings and embedded expressions.
+func (p *parser) scanTemplate(offset int) (string, error) {
+	for p.chr != '`' {
+		switch p.chr {
+		case -1:
+			return "", errors.New("Unterminated template literal")
+		case '\\':
+			p.read() // backslash
+			if p.chr >= 0 {
+				p.read() // escaped character
+			}
+		case '$':
+			p.read() // dollar
+			if p.chr == '{' {
+				p.read() // opening brace
+				if err := p.scanTemplateSubstitution(); err != nil {
+					return "", err
+				}
+			}
+		default:
+			p.read()
+		}
+	}
+
+	p.read() // closing backtick
+	return p.str[offset:p.chrOffset], nil
+}
+
+// scanTemplateSubstitution consumes the body of a ${ ... } substitution up to
+// and including its matching closing brace, skipping over nested braces, string
+// literals and nested template literals so that braces and backticks appearing
+// inside them do not prematurely terminate the substitution.
+func (p *parser) scanTemplateSubstitution() error {
+	depth := 1
+	for depth > 0 {
+		switch p.chr {
+		case -1:
+			return errors.New("Unterminated template literal")
+		case '{':
+			depth++
+			p.read()
+		case '}':
+			depth--
+			p.read()
+		case '`':
+			p.read() // opening backtick of a nested template
+			if _, err := p.scanTemplate(p.chrOffset - 1); err != nil {
+				return err
+			}
+		case '"', '\'':
+			if err := p.skipStringLiteral(p.chr); err != nil {
+				return err
+			}
+		case '\\':
+			p.read()
+			if p.chr >= 0 {
+				p.read()
+			}
+		default:
+			p.read()
+		}
+	}
+	return nil
+}
+
+// skipStringLiteral consumes a single- or double-quoted string literal,
+// beginning at its opening quote, used while scanning template substitutions.
+func (p *parser) skipStringLiteral(quote rune) error {
+	p.read() // opening quote
+	for p.chr != quote {
+		switch {
+		case p.chr < 0, p.chr == '\n', p.chr == '\r':
+			return errors.New("String not terminated")
+		case p.chr == '\\':
+			p.read()
+			if p.chr >= 0 {
+				p.read()
+			}
+		default:
+			p.read()
+		}
+	}
+	p.read() // closing quote
+	return nil
 }
 
 func (p *parser) scanNewline() {

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -211,7 +211,7 @@ Second line \
 			token.VAR, "var", 1,
 			token.IF, "if", 5,
 			token.VAR, "var", 8,
-			token.KEYWORD, "class", 12,
+			token.CLASS, "class", 12,
 			token.EOF, "", 17,
 		)
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -429,9 +429,10 @@ func TestParserErr(t *testing.T) {
 			test("abc.class = 1", nil)
 			test("var class;", "(anonymous): Line 1:5 Unexpected reserved word")
 
-			test("const", "(anonymous): Line 1:1 Unexpected reserved word")
+			// const is now a declaration keyword rather than a reserved word.
+			test("const", "(anonymous): Line 1:6 Unexpected end of input")
 			test("abc.const = 1", nil)
-			test("var const;", "(anonymous): Line 1:5 Unexpected reserved word")
+			test("var const;", "(anonymous): Line 1:5 Unexpected token const")
 
 			test("enum", "(anonymous): Line 1:1 Unexpected reserved word")
 			test("abc.enum = 1", nil)
@@ -463,9 +464,10 @@ func TestParserErr(t *testing.T) {
 			test(`abc.interface = 1`, nil)
 			test(`var interface;`, nil)
 
-			test(`let`, nil)
+			// let is now a declaration keyword rather than an identifier.
+			test(`let`, "(anonymous): Line 1:4 Unexpected end of input")
 			test(`abc.let = 1`, nil)
-			test(`var let;`, nil)
+			test(`var let;`, "(anonymous): Line 1:5 Unexpected token let")
 
 			test(`package`, nil)
 			test(`abc.package = 1`, nil)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -240,7 +240,7 @@ func TestParserErr(t *testing.T) {
 
 		test("a if", "(anonymous): Line 1:3 Unexpected token if")
 
-		test("a class", "(anonymous): Line 1:3 Unexpected reserved word")
+		test("a class", "(anonymous): Line 1:3 Unexpected token class")
 
 		test("break\n", "(anonymous): Line 1:1 Illegal break statement")
 
@@ -393,7 +393,7 @@ func TestParserErr(t *testing.T) {
 
 		test("/\\1/.source", "(anonymous): Line 1:1 Invalid regular expression: re2: Invalid \\1 <backreference>")
 
-		test("var class", "(anonymous): Line 1:5 Unexpected reserved word")
+		test("var class", "(anonymous): Line 1:5 Unexpected token class")
 
 		test("var if", "(anonymous): Line 1:5 Unexpected token if")
 
@@ -426,9 +426,9 @@ func TestParserErr(t *testing.T) {
 		}
 
 		{ // Reserved words
-			test("class", "(anonymous): Line 1:1 Unexpected reserved word")
+			test("class", "(anonymous): Line 1:6 Unexpected end of input")
 			test("abc.class = 1", nil)
-			test("var class;", "(anonymous): Line 1:5 Unexpected reserved word")
+			test("var class;", "(anonymous): Line 1:5 Unexpected token class")
 
 			// const is now a declaration keyword rather than a reserved word.
 			test("const", "(anonymous): Line 1:6 Unexpected end of input")
@@ -443,17 +443,17 @@ func TestParserErr(t *testing.T) {
 			test("abc.export = 1", nil)
 			test("var export;", "(anonymous): Line 1:5 Unexpected reserved word")
 
-			test("extends", "(anonymous): Line 1:1 Unexpected reserved word")
+			test("extends", "(anonymous): Line 1:1 Unexpected token extends")
 			test("abc.extends = 1", nil)
-			test("var extends;", "(anonymous): Line 1:5 Unexpected reserved word")
+			test("var extends;", "(anonymous): Line 1:5 Unexpected token extends")
 
 			test("import", "(anonymous): Line 1:1 Unexpected reserved word")
 			test("abc.import = 1", nil)
 			test("var import;", "(anonymous): Line 1:5 Unexpected reserved word")
 
-			test("super", "(anonymous): Line 1:1 Unexpected reserved word")
+			test("super", nil)
 			test("abc.super = 1", nil)
-			test("var super;", "(anonymous): Line 1:5 Unexpected reserved word")
+			test("var super;", "(anonymous): Line 1:5 Unexpected token super")
 		}
 
 		{ // Reserved words (strict)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -60,8 +60,9 @@ func TestParseFile(t *testing.T) {
 		_, err = ParseFile(nil, "", `/(?!def)abc/; return`, IgnoreRegExpErrors)
 		is(err, "(anonymous): Line 1:15 Illegal return statement")
 
+		// `..` begins an (incomplete) ellipsis, so it lexes as an illegal token.
 		_, err = ParseFile(nil, "/make-sure-file-path-is-returned-not-anonymous", `a..`, 0)
-		is(err, "/make-sure-file-path-is-returned-not-anonymous: Line 1:3 Unexpected token .")
+		is(err, "/make-sure-file-path-is-returned-not-anonymous: Line 1:2 Unexpected token ILLEGAL (and 1 more errors)")
 	})
 }
 

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -86,6 +86,8 @@ func (p *parser) parseStatement() ast.Statement {
 		return p.parseVariableStatement()
 	case token.LET, token.CONST:
 		return p.parseLexicalDeclaration()
+	case token.CLASS:
+		return p.parseClass(true)
 	case token.FUNCTION:
 		return p.parseFunctionStatement()
 	case token.SWITCH:
@@ -315,6 +317,96 @@ func (p *parser) parseFunction(declaration bool) *ast.FunctionLiteral {
 	p.parseFunctionBlock(node)
 	node.Source = p.slice(node.Idx0(), node.Idx1())
 
+	return node
+}
+
+func (p *parser) parseClass(declaration bool) *ast.ClassLiteral {
+	node := &ast.ClassLiteral{
+		Class: p.expect(token.CLASS),
+	}
+
+	if p.token == token.IDENTIFIER {
+		node.Name = p.parseIdentifier()
+	} else if declaration {
+		p.expect(token.IDENTIFIER)
+	}
+
+	if p.token == token.EXTENDS {
+		p.next()
+		node.SuperClass = p.parseLeftHandSideExpressionAllowCall()
+	}
+
+	p.expect(token.LEFT_BRACE)
+	for p.token != token.RIGHT_BRACE && p.token != token.EOF {
+		if p.token == token.SEMICOLON {
+			p.next()
+			continue
+		}
+		node.Body = append(node.Body, p.parseClassElement())
+	}
+	node.RightBrace = p.expect(token.RIGHT_BRACE)
+	node.Source = p.slice(node.Idx0(), node.Idx1())
+
+	return node
+}
+
+func (p *parser) parseClassElement() *ast.ClassElement {
+	element := &ast.ClassElement{Kind: "method"}
+	methodIdx := p.idx
+
+	// static modifier (unless "static" is itself the method name).
+	if p.token == token.IDENTIFIER && p.literal == "static" {
+		p.next()
+		if p.token == token.LEFT_PARENTHESIS {
+			element.Key = "static"
+			element.Method = p.parseClassMethodDefinition(methodIdx)
+			return element
+		}
+		element.Static = true
+		methodIdx = p.idx
+	}
+
+	// get / set accessor (unless "get"/"set" is itself the method name).
+	if p.token == token.IDENTIFIER && (p.literal == "get" || p.literal == "set") {
+		accessor := p.literal
+		p.next()
+		if p.token == token.LEFT_PARENTHESIS {
+			element.Key = accessor
+			element.Method = p.parseClassMethodDefinition(methodIdx)
+			return element
+		}
+		element.Kind = accessor
+		p.parseClassElementKey(element)
+		element.Method = p.parseClassMethodDefinition(methodIdx)
+		return element
+	}
+
+	p.parseClassElementKey(element)
+	element.Method = p.parseClassMethodDefinition(methodIdx)
+	if !element.Static && element.Kind == "method" && element.Key == "constructor" {
+		element.Kind = "constructor"
+	}
+	return element
+}
+
+func (p *parser) parseClassElementKey(element *ast.ClassElement) {
+	if p.token == token.LEFT_BRACKET {
+		keyExpr, _ := p.parseComputedPropertyKey()
+		element.KeyExpression = keyExpr
+		return
+	}
+	_, key := p.parseObjectPropertyKey()
+	element.Key = key
+}
+
+func (p *parser) parseClassMethodDefinition(idx file.Idx) *ast.FunctionLiteral {
+	parameterList := p.parseFunctionParameterList()
+	node := &ast.FunctionLiteral{
+		Function:      idx,
+		ParameterList: parameterList,
+	}
+	p.parseFunctionBlock(node)
+	node.Source = p.slice(node.Idx0(), node.Idx1())
 	return node
 }
 

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -84,6 +84,8 @@ func (p *parser) parseStatement() ast.Statement {
 		return p.parseWithStatement()
 	case token.VAR:
 		return p.parseVariableStatement()
+	case token.LET, token.CONST:
+		return p.parseLexicalDeclaration()
 	case token.FUNCTION:
 		return p.parseFunctionStatement()
 	case token.SWITCH:
@@ -636,18 +638,26 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 	var left []ast.Expression
 
 	forIn := false
+	var lexicalKind token.Token
 	if p.token != token.SEMICOLON {
 		allowIn := p.scope.allowIn
 		p.scope.allowIn = false
-		if p.token == token.VAR {
+		if p.token == token.VAR || p.token == token.LET || p.token == token.CONST {
 			tokenIdx := p.idx
+			kind := p.token
 			var varComments []*ast.Comment
 			if p.mode&StoreComments != 0 {
 				varComments = p.comments.FetchAll()
 				p.comments.Unset()
 			}
 			p.next()
-			list := p.parseVariableDeclarationList(tokenIdx)
+			var list []ast.Expression
+			if kind == token.VAR {
+				list = p.parseVariableDeclarationList(tokenIdx)
+			} else {
+				lexicalKind = kind
+				list = p.parseLexicalBindingList()
+			}
 			if len(list) == 1 && p.token == token.IN {
 				if p.mode&StoreComments != 0 {
 					p.comments.Unset()
@@ -683,6 +693,7 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 
 		forin := p.parseForIn(left[0])
 		forin.For = idx
+		forin.Lexical = lexicalKind
 		if p.mode&StoreComments != 0 {
 			p.comments.CommentMap.AddComments(forin, comments, ast.LEADING)
 			p.comments.CommentMap.AddComments(forin, forComments, ast.FOR)
@@ -697,6 +708,7 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 	initializer := &ast.SequenceExpression{Sequence: left}
 	forstatement := p.parseFor(initializer)
 	forstatement.For = idx
+	forstatement.Lexical = lexicalKind
 	if p.mode&StoreComments != 0 {
 		p.comments.CommentMap.AddComments(forstatement, comments, ast.LEADING)
 		p.comments.CommentMap.AddComments(forstatement, forComments, ast.FOR)
@@ -724,6 +736,47 @@ func (p *parser) parseVariableStatement() *ast.VariableStatement {
 	p.semicolon()
 
 	return statement
+}
+
+func (p *parser) parseLexicalDeclaration() *ast.LexicalDeclaration {
+	var comments []*ast.Comment
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
+	}
+	kind := p.token // token.LET or token.CONST
+	idx := p.expect(kind)
+
+	// Parse the binding list without registering it for var-style hoisting;
+	// lexical bindings are scoped to their enclosing block.
+	list := p.parseLexicalBindingList()
+
+	statement := &ast.LexicalDeclaration{
+		Idx:   idx,
+		Token: kind,
+		List:  list,
+	}
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(statement, comments, ast.LEADING)
+		p.comments.Unset()
+	}
+	p.semicolon()
+
+	return statement
+}
+
+// parseLexicalBindingList parses a comma-separated list of let/const bindings.
+// Unlike parseVariableDeclarationList it does not declare the names in the
+// surrounding function scope, since lexical declarations are block-scoped.
+func (p *parser) parseLexicalBindingList() []ast.Expression {
+	var list []ast.Expression
+	for {
+		list = append(list, p.parseVariableDeclaration(nil))
+		if p.token != token.COMMA {
+			break
+		}
+		p.next()
+	}
+	return list
 }
 
 func (p *parser) parseDoWhileStatement() ast.Statement {

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"github.com/robertkrimen/otto/ast"
+	"github.com/robertkrimen/otto/file"
 	"github.com/robertkrimen/otto/token"
 )
 
@@ -293,6 +294,81 @@ func (p *parser) parseFunctionBlock(node *ast.FunctionLiteral) {
 	}()
 	node.Body = p.parseBlockStatement()
 	node.DeclarationList = p.scope.declarationList
+}
+
+// arrowParameterList converts an already-parsed expression (the contents of a
+// parenthesised group) into a list of arrow function parameters. It only
+// accepts plain identifiers; defaults, rest and destructuring are not yet
+// supported.
+func arrowParameterList(expression ast.Expression) ([]*ast.Identifier, bool) {
+	switch expr := expression.(type) {
+	case *ast.Identifier:
+		return []*ast.Identifier{expr}, true
+	case *ast.SequenceExpression:
+		list := make([]*ast.Identifier, 0, len(expr.Sequence))
+		for _, item := range expr.Sequence {
+			identifier, ok := item.(*ast.Identifier)
+			if !ok {
+				return nil, false
+			}
+			list = append(list, identifier)
+		}
+		return list, true
+	default:
+		return nil, false
+	}
+}
+
+// parseArrowFunction parses the "=> body" portion of an arrow function, given a
+// parameter list that has already been collected by the caller. p.token is
+// expected to be token.ARROW.
+func (p *parser) parseArrowFunction(start file.Idx, list []*ast.Identifier, opening, closing file.Idx) ast.Expression {
+	node := &ast.FunctionLiteral{
+		Function: start,
+		IsArrow:  true,
+		ParameterList: &ast.ParameterList{
+			List:    list,
+			Opening: opening,
+			Closing: closing,
+		},
+	}
+	if p.mode&StoreComments != 0 {
+		p.comments.Unset()
+	}
+	p.expect(token.ARROW)
+	p.parseArrowFunctionBody(node)
+	node.Source = p.slice(node.Idx0(), node.Idx1())
+
+	return node
+}
+
+func (p *parser) parseArrowFunctionBody(node *ast.FunctionLiteral) {
+	if p.token == token.LEFT_BRACE {
+		// A block body behaves like an ordinary function body.
+		p.openScope()
+		inFunction := p.scope.inFunction
+		p.scope.inFunction = true
+		defer func() {
+			p.scope.inFunction = inFunction
+			p.closeScope()
+		}()
+		node.Body = p.parseBlockStatement()
+		node.DeclarationList = p.scope.declarationList
+		return
+	}
+
+	// A concise body is a single expression with an implicit return.
+	expression := p.parseAssignmentExpression()
+	node.Body = &ast.BlockStatement{
+		LeftBrace: expression.Idx0(),
+		List: []ast.Statement{
+			&ast.ReturnStatement{
+				Return:   expression.Idx0(),
+				Argument: expression,
+			},
+		},
+		RightBrace: expression.Idx1(),
+	}
 }
 
 func (p *parser) parseDebuggerStatement() ast.Statement {

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -610,6 +610,12 @@ func (p *parser) parseIterationStatement() ast.Statement {
 	return p.parseStatement()
 }
 
+// isForOf reports whether the current token is the contextual keyword "of",
+// used to recognise a for-of loop.
+func (p *parser) isForOf() bool {
+	return p.token == token.IDENTIFIER && p.literal == "of"
+}
+
 func (p *parser) parseForIn(into ast.Expression) *ast.ForInStatement {
 	// Already have consumed "<into> in"
 
@@ -670,6 +676,7 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 	var left []ast.Expression
 
 	forIn := false
+	forOf := false
 	var lexicalKind token.Token
 	if p.token != token.SEMICOLON {
 		allowIn := p.scope.allowIn
@@ -690,11 +697,12 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 				lexicalKind = kind
 				list = p.parseLexicalBindingList()
 			}
-			if len(list) == 1 && p.token == token.IN {
+			if len(list) == 1 && (p.token == token.IN || p.isForOf()) {
 				if p.mode&StoreComments != 0 {
 					p.comments.Unset()
 				}
-				p.next() // in
+				forOf = p.isForOf()
+				p.next() // in or of
 				forIn = true
 				left = []ast.Expression{list[0]} // There is only one declaration
 			} else {
@@ -705,7 +713,8 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 			}
 		} else {
 			left = append(left, p.parseExpression())
-			if p.token == token.IN {
+			if p.token == token.IN || p.isForOf() {
+				forOf = p.isForOf()
 				p.next()
 				forIn = true
 			}
@@ -726,6 +735,7 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 		forin := p.parseForIn(left[0])
 		forin.For = idx
 		forin.Lexical = lexicalKind
+		forin.Of = forOf
 		if p.mode&StoreComments != 0 {
 			p.comments.CommentMap.AddComments(forin, comments, ast.LEADING)
 			p.comments.CommentMap.AddComments(forin, forComments, ast.FOR)

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -223,8 +223,10 @@ func (p *parser) parseFunctionParameterList() *ast.ParameterList {
 	}
 	var list []*ast.Identifier
 	var defaults []ast.Expression
+	var targets []ast.Expression
 	var rest *ast.Identifier
 	hasDefault := false
+	hasTarget := false
 	for p.token != token.RIGHT_PARENTHESIS && p.token != token.EOF {
 		if p.token == token.ELLIPSIS {
 			// A rest parameter (...name) must be the last parameter.
@@ -236,23 +238,36 @@ func (p *parser) parseFunctionParameterList() *ast.ParameterList {
 			rest = p.parseIdentifier()
 			break
 		}
-		if p.token != token.IDENTIFIER {
-			p.expect(token.IDENTIFIER)
-		} else {
-			identifier := p.parseIdentifier()
-			list = append(list, identifier)
 
-			var def ast.Expression
-			if p.token == token.ASSIGN {
-				if p.mode&StoreComments != 0 {
-					p.comments.Unset()
-				}
+		var target ast.Expression
+		switch p.token {
+		case token.LEFT_BRACKET, token.LEFT_BRACE:
+			// A destructuring parameter, e.g. function f({a}, [b]) {}.
+			target = p.parseBindingTarget()
+			list = append(list, &ast.Identifier{Idx: p.idx})
+			hasTarget = true
+		case token.IDENTIFIER:
+			list = append(list, p.parseIdentifier())
+		default:
+			p.expect(token.IDENTIFIER)
+			if p.token != token.RIGHT_PARENTHESIS {
 				p.next()
-				def = p.parseAssignmentExpression()
-				hasDefault = true
 			}
-			defaults = append(defaults, def)
+			continue
 		}
+		targets = append(targets, target)
+
+		var def ast.Expression
+		if p.token == token.ASSIGN {
+			if p.mode&StoreComments != 0 {
+				p.comments.Unset()
+			}
+			p.next()
+			def = p.parseAssignmentExpression()
+			hasDefault = true
+		}
+		defaults = append(defaults, def)
+
 		if p.token != token.RIGHT_PARENTHESIS {
 			if p.mode&StoreComments != 0 {
 				p.comments.Unset()
@@ -268,10 +283,13 @@ func (p *parser) parseFunctionParameterList() *ast.ParameterList {
 		Rest:    rest,
 		Closing: closing,
 	}
-	// Only retain the defaults slice if at least one parameter has a default,
-	// keeping the common (default-free) case unchanged.
+	// Only retain the parallel slices when they carry information, keeping the
+	// common (plain-identifier) case unchanged.
 	if hasDefault {
 		node.Defaults = defaults
+	}
+	if hasTarget {
+		node.Targets = targets
 	}
 
 	return node
@@ -426,37 +444,75 @@ func (p *parser) parseFunctionBlock(node *ast.FunctionLiteral) {
 // parenthesised group) into a list of arrow function parameters. It only
 // accepts plain identifiers; defaults, rest and destructuring are not yet
 // supported.
-func arrowParameterList(expression ast.Expression) ([]*ast.Identifier, bool) {
-	switch expr := expression.(type) {
-	case *ast.Identifier:
-		return []*ast.Identifier{expr}, true
-	case *ast.SequenceExpression:
-		list := make([]*ast.Identifier, 0, len(expr.Sequence))
-		for _, item := range expr.Sequence {
-			identifier, ok := item.(*ast.Identifier)
+func arrowParameterList(expression ast.Expression, opening, closing file.Idx) (*ast.ParameterList, bool) {
+	pl := &ast.ParameterList{Opening: opening, Closing: closing}
+	hasTarget := false
+	hasDefault := false
+
+	add := func(e ast.Expression) bool {
+		var def ast.Expression
+		if assign, ok := e.(*ast.AssignExpression); ok {
+			if assign.Operator != token.ASSIGN {
+				return false
+			}
+			def = assign.Right
+			e = assign.Left
+			hasDefault = true
+		}
+
+		var name *ast.Identifier
+		var target ast.Expression
+		switch t := e.(type) {
+		case *ast.Identifier:
+			name = t
+		case *ast.ArrayLiteral, *ast.ObjectLiteral:
+			pattern, ok := literalToPattern(e)
 			if !ok {
+				return false
+			}
+			target = pattern
+			name = &ast.Identifier{Idx: e.Idx0()}
+			hasTarget = true
+		case *ast.ArrayPattern, *ast.ObjectPattern:
+			target = e
+			name = &ast.Identifier{Idx: e.Idx0()}
+			hasTarget = true
+		default:
+			return false
+		}
+		pl.List = append(pl.List, name)
+		pl.Targets = append(pl.Targets, target)
+		pl.Defaults = append(pl.Defaults, def)
+		return true
+	}
+
+	if seq, ok := expression.(*ast.SequenceExpression); ok {
+		for _, item := range seq.Sequence {
+			if !add(item) {
 				return nil, false
 			}
-			list = append(list, identifier)
 		}
-		return list, true
-	default:
+	} else if !add(expression) {
 		return nil, false
 	}
+
+	if !hasTarget {
+		pl.Targets = nil
+	}
+	if !hasDefault {
+		pl.Defaults = nil
+	}
+	return pl, true
 }
 
 // parseArrowFunction parses the "=> body" portion of an arrow function, given a
 // parameter list that has already been collected by the caller. p.token is
 // expected to be token.ARROW.
-func (p *parser) parseArrowFunction(start file.Idx, list []*ast.Identifier, opening, closing file.Idx) ast.Expression {
+func (p *parser) parseArrowFunction(start file.Idx, params *ast.ParameterList) ast.Expression {
 	node := &ast.FunctionLiteral{
-		Function: start,
-		IsArrow:  true,
-		ParameterList: &ast.ParameterList{
-			List:    list,
-			Opening: opening,
-			Closing: closing,
-		},
+		Function:      start,
+		IsArrow:       true,
+		ParameterList: params,
 	}
 	if p.mode&StoreComments != 0 {
 		p.comments.Unset()

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -221,8 +221,19 @@ func (p *parser) parseFunctionParameterList() *ast.ParameterList {
 	}
 	var list []*ast.Identifier
 	var defaults []ast.Expression
+	var rest *ast.Identifier
 	hasDefault := false
 	for p.token != token.RIGHT_PARENTHESIS && p.token != token.EOF {
+		if p.token == token.ELLIPSIS {
+			// A rest parameter (...name) must be the last parameter.
+			p.next()
+			if p.token != token.IDENTIFIER {
+				p.expect(token.IDENTIFIER)
+				break
+			}
+			rest = p.parseIdentifier()
+			break
+		}
 		if p.token != token.IDENTIFIER {
 			p.expect(token.IDENTIFIER)
 		} else {
@@ -252,6 +263,7 @@ func (p *parser) parseFunctionParameterList() *ast.ParameterList {
 	node := &ast.ParameterList{
 		Opening: opening,
 		List:    list,
+		Rest:    rest,
 		Closing: closing,
 	}
 	// Only retain the defaults slice if at least one parameter has a default,

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -220,12 +220,25 @@ func (p *parser) parseFunctionParameterList() *ast.ParameterList {
 		p.comments.Unset()
 	}
 	var list []*ast.Identifier
+	var defaults []ast.Expression
+	hasDefault := false
 	for p.token != token.RIGHT_PARENTHESIS && p.token != token.EOF {
 		if p.token != token.IDENTIFIER {
 			p.expect(token.IDENTIFIER)
 		} else {
 			identifier := p.parseIdentifier()
 			list = append(list, identifier)
+
+			var def ast.Expression
+			if p.token == token.ASSIGN {
+				if p.mode&StoreComments != 0 {
+					p.comments.Unset()
+				}
+				p.next()
+				def = p.parseAssignmentExpression()
+				hasDefault = true
+			}
+			defaults = append(defaults, def)
 		}
 		if p.token != token.RIGHT_PARENTHESIS {
 			if p.mode&StoreComments != 0 {
@@ -236,11 +249,18 @@ func (p *parser) parseFunctionParameterList() *ast.ParameterList {
 	}
 	closing := p.expect(token.RIGHT_PARENTHESIS)
 
-	return &ast.ParameterList{
+	node := &ast.ParameterList{
 		Opening: opening,
 		List:    list,
 		Closing: closing,
 	}
+	// Only retain the defaults slice if at least one parameter has a default,
+	// keeping the common (default-free) case unchanged.
+	if hasDefault {
+		node.Defaults = defaults
+	}
+
+	return node
 }
 
 func (p *parser) parseFunctionStatement() *ast.FunctionStatement {

--- a/rest_params_test.go
+++ b/rest_params_test.go
@@ -1,0 +1,52 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestRestParameters(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// All arguments collected.
+		test(`
+            function f(...args) { return args.length; }
+            f(1, 2, 3);
+        `, 3)
+
+		// The rest parameter is a real array.
+		test(`
+            function f(...args) { return Array.isArray(args); }
+            f(1);
+        `, true)
+
+		test(`
+            function f(...args) { return args.join("-"); }
+            f("a", "b");
+        `, "a-b")
+
+		// Rest after fixed parameters.
+		test(`
+            function f(a, b, ...rest) { return rest.join(","); }
+            f(1, 2, 3, 4, 5);
+        `, "3,4,5")
+
+		// No trailing arguments yields an empty array.
+		test(`
+            function f(a, ...rest) { return rest.length; }
+            f(1);
+        `, 0)
+
+		// Rest combined with a default parameter.
+		test(`
+            function f(a = 5, ...rest) { return a + "," + rest.length; }
+            f(undefined, 1, 2);
+        `, "5,2")
+
+		// Spread-free higher-order use.
+		test(`
+            function sum(...ns) { return ns.reduce(function(a, b) { return a + b; }, 0); }
+            sum(1, 2, 3, 4);
+        `, 10)
+	})
+}

--- a/spread_test.go
+++ b/spread_test.go
@@ -1,0 +1,56 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestSpreadCall(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            function f(a, b, c) { return a + b + c; }
+            f(...[1, 2, 3]);
+        `, 6)
+
+		// Spread mixed with fixed arguments.
+		test(`
+            function f(a, b, c, d) { return [a, b, c, d].join(","); }
+            f(1, ...[2, 3], 4);
+        `, "1,2,3,4")
+
+		// Spread into a built-in.
+		test(`Math.max(...[4, 1, 9, 2]);`, 9)
+
+		// Spread feeding a rest parameter.
+		test(`
+            function f(x, ...r) { return x + ":" + r.join(","); }
+            f(...[1, 2, 3, 4]);
+        `, "1:2,3,4")
+	})
+}
+
+func TestSpreadArrayLiteral(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var a = [1, 2];
+            [0, ...a, 3].join(",");
+        `, "0,1,2,3")
+
+		test(`
+            var a = [1, 2], b = [3, 4];
+            [...a, ...b].length;
+        `, 4)
+
+		// Spreading a string iterates its characters.
+		test(`[..."abc"].join("-");`, "a-b-c")
+
+		// Spreading an array-like object.
+		test(`
+            var o = { 0: "x", 1: "y", length: 2 };
+            [...o].join(",");
+        `, "x,y")
+	})
+}

--- a/stash.go
+++ b/stash.go
@@ -117,6 +117,7 @@ type dclProperty struct {
 	mutable   bool
 	deletable bool
 	readable  bool
+	constant  bool // a const binding: assignment always throws a TypeError
 }
 
 func (rt *runtime) newDeclarationStash(outer stasher) *dclStash {
@@ -165,10 +166,25 @@ func (s *dclStash) createBinding(name string, deletable bool, value Value) {
 	}
 }
 
+// createImmutableBinding creates and initialises a const binding. Any later
+// assignment to it throws a TypeError.
+func (s *dclStash) createImmutableBinding(name string, value Value) {
+	s.property[name] = dclProperty{
+		value:     value,
+		mutable:   false,
+		deletable: false,
+		readable:  true,
+		constant:  true,
+	}
+}
+
 func (s *dclStash) setBinding(name string, value Value, strict bool) {
 	prop, exists := s.property[name]
 	if !exists {
 		panic(fmt.Errorf("setBinding: %s: missing", name))
+	}
+	if prop.constant {
+		panic(s.rt.panicTypeError("Assignment to constant variable."))
 	}
 	if prop.mutable {
 		prop.value = value

--- a/tagged_template_test.go
+++ b/tagged_template_test.go
@@ -13,13 +13,13 @@ func TestTaggedTemplate(t *testing.T) {
             function tag(strings, ...values) {
                 return strings.join("|") + "#" + values.join(",");
             }
-            tag` + "`a${1}b${2}c`" + `;
+            tag`+"`a${1}b${2}c`"+`;
         `, "a|b|c#1,2")
 
 		// strings always has one more element than values.
 		test(`
             function tag(strings, ...values) { return strings.length + ":" + values.length; }
-            tag` + "`${1}${2}${3}`" + `;
+            tag`+"`${1}${2}${3}`"+`;
         `, "4:3")
 
 		// Cooked vs raw strings.

--- a/tagged_template_test.go
+++ b/tagged_template_test.go
@@ -1,0 +1,51 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestTaggedTemplate(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// The tag receives the cooked string parts and the interpolated values.
+		test(`
+            function tag(strings, ...values) {
+                return strings.join("|") + "#" + values.join(",");
+            }
+            tag` + "`a${1}b${2}c`" + `;
+        `, "a|b|c#1,2")
+
+		// strings always has one more element than values.
+		test(`
+            function tag(strings, ...values) { return strings.length + ":" + values.length; }
+            tag` + "`${1}${2}${3}`" + `;
+        `, "4:3")
+
+		// Cooked vs raw strings.
+		test(`
+            function cooked(strings) { return strings[0]; }
+            cooked`+"`a\\nb${1}`"+`;
+        `, "a\nb")
+		test(`
+            function raw(strings) { return strings.raw[0]; }
+            raw`+"`a\\nb${1}`"+`;
+        `, `a\nb`)
+
+		// A method tag is called with the right `this`.
+		test(`
+            var o = { x: "X", tag(strings) { return this.x + strings[0]; } };
+            o.tag`+"`y`"+`;
+        `, "Xy")
+	})
+}
+
+func TestStringRaw(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test("String.raw`a\\tb`;", `a\tb`)
+		test("String.raw`x${1}y${2}z`;", "x1y2z")
+		test("String.raw`line\\nbreak ${1 + 1}`;", `line\nbreak 2`)
+	})
+}

--- a/template_test.go
+++ b/template_test.go
@@ -17,7 +17,7 @@ func TestTemplateLiteral(t *testing.T) {
 		// Single substitution.
 		test(`
             var name = "world";
-            ` + "`hello ${name}`" + `;
+            `+"`hello ${name}`"+`;
         `, "hello world")
 
 		// Expressions in substitutions.
@@ -46,7 +46,7 @@ func TestTemplateLiteral_expressions(t *testing.T) {
 		// A ternary inside a substitution.
 		test(`
             var x = 5;
-            ` + "`${x > 3 ? \"big\" : \"small\"}`" + `;
+            `+"`${x > 3 ? \"big\" : \"small\"}`"+`;
         `, "big")
 
 		// An object's toString is invoked (ToString semantics).

--- a/template_test.go
+++ b/template_test.go
@@ -1,0 +1,71 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestTemplateLiteral(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// A template with no substitutions is just a string.
+		test("`hello`", "hello")
+
+		// typeof a template literal is "string".
+		test("typeof `abc`", "string")
+
+		// Single substitution.
+		test(`
+            var name = "world";
+            ` + "`hello ${name}`" + `;
+        `, "hello world")
+
+		// Expressions in substitutions.
+		test("`${1 + 2} and ${3 * 4}`", "3 and 12")
+
+		// Adjacent substitutions and surrounding text.
+		test("`a${1}b${2}c`", "a1b2c")
+
+		// A leading and trailing substitution.
+		test("`${1}middle${2}`", "1middle2")
+
+		// Escape sequences are cooked.
+		test("`line1\\nline2`", "line1\nline2")
+		test("`tab\\there`", "tab\there")
+		test("`\\u0041\\u{1F600}`", "A\U0001F600")
+	})
+}
+
+func TestTemplateLiteral_expressions(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Function calls, including arrow callbacks, inside a substitution.
+		test("`sum=${[1, 2, 3].reduce((a, b) => a + b, 0)}`", "sum=6")
+
+		// A ternary inside a substitution.
+		test(`
+            var x = 5;
+            ` + "`${x > 3 ? \"big\" : \"small\"}`" + `;
+        `, "big")
+
+		// An object's toString is invoked (ToString semantics).
+		test("`value ${ {toString: function() { return \"X\"; }} }`", "value X")
+	})
+}
+
+func TestTemplateLiteral_nesting(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// A nested template literal inside a substitution.
+		test("`outer ${`inner ${1 + 1}`} end`", "outer inner 2 end")
+
+		// A string containing a closing brace inside a substitution must not
+		// terminate the substitution early.
+		test("`a ${ \"}b{\" } c`", "a }b{ c")
+
+		// Object literal (with its braces) inside a substitution.
+		test("`${ {a: 1}.a }`", "1")
+	})
+}

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -116,6 +116,10 @@ const (
 	DEBUGGER
 	// Instance of.
 	INSTANCEOF
+	// Classes.
+	CLASS
+	EXTENDS
+	SUPER
 )
 
 var token2string = [...]string{
@@ -209,6 +213,9 @@ var token2string = [...]string{
 	CONTINUE:                    "continue",
 	DEBUGGER:                    "debugger",
 	INSTANCEOF:                  "instanceof",
+	CLASS:                       "class",
+	EXTENDS:                     "extends",
+	SUPER:                       "super",
 }
 
 var keywordTable = map[string]keyword{
@@ -297,8 +304,13 @@ var keywordTable = map[string]keyword{
 		token: INSTANCEOF,
 	},
 	"class": {
-		token:         KEYWORD,
-		futureKeyword: true,
+		token: CLASS,
+	},
+	"extends": {
+		token: EXTENDS,
+	},
+	"super": {
+		token: SUPER,
 	},
 	"enum": {
 		token:         KEYWORD,
@@ -308,15 +320,7 @@ var keywordTable = map[string]keyword{
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"extends": {
-		token:         KEYWORD,
-		futureKeyword: true,
-	},
 	"import": {
-		token:         KEYWORD,
-		futureKeyword: true,
-	},
-	"super": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -76,6 +76,7 @@ const (
 	SEMICOLON         // ;
 	COLON             // :
 	QUESTION_MARK     // ?
+	ARROW             // =>
 	// Basic flow - keywords below here.
 	_
 	IF
@@ -173,6 +174,7 @@ var token2string = [...]string{
 	SEMICOLON:                   ";",
 	COLON:                       ":",
 	QUESTION_MARK:               "?",
+	ARROW:                       "=>",
 	IF:                          "if",
 	IN:                          "in",
 	DO:                          "do",

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -85,6 +85,8 @@ const (
 	DO
 	// Declarations.
 	VAR
+	LET
+	CONST
 	FOR
 	NEW
 	TRY
@@ -181,6 +183,8 @@ var token2string = [...]string{
 	IN:                          "in",
 	DO:                          "do",
 	VAR:                         "var",
+	LET:                         "let",
+	CONST:                       "const",
 	FOR:                         "for",
 	NEW:                         "new",
 	TRY:                         "try",
@@ -217,6 +221,12 @@ var keywordTable = map[string]keyword{
 	},
 	"var": {
 		token: VAR,
+	},
+	"let": {
+		token: LET,
+	},
+	"const": {
+		token: CONST,
 	},
 	"for": {
 		token: FOR,
@@ -284,10 +294,6 @@ var keywordTable = map[string]keyword{
 	"instanceof": {
 		token: INSTANCEOF,
 	},
-	"const": {
-		token:         KEYWORD,
-		futureKeyword: true,
-	},
 	"class": {
 		token:         KEYWORD,
 		futureKeyword: true,
@@ -318,11 +324,6 @@ var keywordTable = map[string]keyword{
 		strict:        true,
 	},
 	"interface": {
-		token:         KEYWORD,
-		futureKeyword: true,
-		strict:        true,
-	},
-	"let": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -70,6 +70,7 @@ const (
 	LEFT_BRACE       // {
 	COMMA            // ,
 	PERIOD           // .
+	ELLIPSIS         // ...
 	// Right operators.
 	RIGHT_PARENTHESIS // )
 	RIGHT_BRACKET     // ]
@@ -172,6 +173,7 @@ var token2string = [...]string{
 	LEFT_BRACE:                  "{",
 	COMMA:                       ",",
 	PERIOD:                      ".",
+	ELLIPSIS:                    "...",
 	RIGHT_PARENTHESIS:           ")",
 	RIGHT_BRACKET:               "]",
 	RIGHT_BRACE:                 "}",

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -16,6 +16,7 @@ const (
 	NULL
 	NUMBER
 	IDENTIFIER
+	TEMPLATE
 	// Maths.
 	PLUS      // +
 	MINUS     // -
@@ -124,6 +125,7 @@ var token2string = [...]string{
 	NULL:                        "NULL",
 	NUMBER:                      "NUMBER",
 	IDENTIFIER:                  "IDENTIFIER",
+	TEMPLATE:                    "TEMPLATE",
 	PLUS:                        "+",
 	MINUS:                       "-",
 	MULTIPLY:                    "*",

--- a/tools/gen-jscore/.gen-jscore.yaml
+++ b/tools/gen-jscore/.gen-jscore.yaml
@@ -152,6 +152,8 @@ types:
         value: rt.global.StringPrototype
       - name: fromCharCode
         function: 1
+      - name: raw
+        function: 1
     prototype:
       objectClass: String
       prototype: Object

--- a/tools/gen-tokens/.gen-tokens.yaml
+++ b/tools/gen-tokens/.gen-tokens.yaml
@@ -182,18 +182,17 @@ tokens:
   - group: Instance of
   - name: INSTANCEOF
 
+  - group: Classes
+  - name: CLASS
+  - name: EXTENDS
+  - name: SUPER
+
   # Future
-  - name: class
-    future: true
   - name: enum
     future: true
   - name: export
     future: true
-  - name: extends
-    future: true
   - name: import
-    future: true
-  - name: super
     future: true
 
   # Future Strict items

--- a/tools/gen-tokens/.gen-tokens.yaml
+++ b/tools/gen-tokens/.gen-tokens.yaml
@@ -11,6 +11,7 @@ tokens:
   - name: "NULL"
   - name: NUMBER
   - name: IDENTIFIER
+  - name: TEMPLATE
 
   - group: Maths
   - name: PLUS

--- a/tools/gen-tokens/.gen-tokens.yaml
+++ b/tools/gen-tokens/.gen-tokens.yaml
@@ -143,6 +143,8 @@ tokens:
 
   - group: Declarations
   - name: VAR
+  - name: LET
+  - name: CONST
   - name: FOR
   - name: NEW
   - name: TRY
@@ -179,8 +181,6 @@ tokens:
   - name: INSTANCEOF
 
   # Future
-  - name: const
-    future: true
   - name: class
     future: true
   - name: enum
@@ -199,9 +199,6 @@ tokens:
     future: true
     strict: true
   - name: interface
-    future: true
-    strict: true
-  - name: let
     future: true
     strict: true
   - name: package

--- a/tools/gen-tokens/.gen-tokens.yaml
+++ b/tools/gen-tokens/.gen-tokens.yaml
@@ -118,6 +118,8 @@ tokens:
     symbol: ","
   - name: PERIOD
     symbol: "."
+  - name: ELLIPSIS
+    symbol: "..."
 
   - group: Right operators
   - name: RIGHT_PARENTHESIS

--- a/tools/gen-tokens/.gen-tokens.yaml
+++ b/tools/gen-tokens/.gen-tokens.yaml
@@ -131,6 +131,8 @@ tokens:
     symbol: ":"
   - name: QUESTION_MARK
     symbol: "?"
+  - name: ARROW
+    symbol: "=>"
 
   - group: Basic flow - keywords below here
   - name: _

--- a/type_function.go
+++ b/type_function.go
@@ -119,6 +119,12 @@ type nodeFunctionObject struct {
 	// this holds the lexically captured `this` for arrow functions. It is
 	// only meaningful when node.isArrow is true.
 	this Value
+	// homeObject is the object a class/method was defined on, used to resolve
+	// `super` references. It is nil for ordinary functions.
+	homeObject *object
+	// defaultDerivedCtor marks a synthesised default constructor of a derived
+	// class, which forwards its arguments to the super constructor.
+	defaultDerivedCtor bool
 }
 
 func (rt *runtime) newNodeFunctionObject(node *nodeFunctionLiteral, stash stasher) *object {
@@ -220,6 +226,10 @@ func (o *object) call(this Value, argumentList []Value, eval bool, frm frame) Va
 		defer func() {
 			rt.leaveScope()
 		}()
+		// A default derived constructor implicitly forwards to super(...args).
+		if fn.defaultDerivedCtor {
+			rt.superConstructor().call(this, argumentList, false, frm)
+		}
 		callValue := rt.cmplCallNodeFunction(o, stash, fn.node, argumentList)
 		if value, valid := callValue.value.(result); valid {
 			return value.value

--- a/type_function.go
+++ b/type_function.go
@@ -116,6 +116,9 @@ func (fn bindFunctionObject) construct(argumentList []Value) Value {
 type nodeFunctionObject struct {
 	node  *nodeFunctionLiteral
 	stash stasher
+	// this holds the lexically captured `this` for arrow functions. It is
+	// only meaningful when node.isArrow is true.
+	this Value
 }
 
 func (rt *runtime) newNodeFunctionObject(node *nodeFunctionLiteral, stash stasher) *object {
@@ -203,6 +206,11 @@ func (o *object) call(this Value, argumentList []Value, eval bool, frm frame) Va
 
 	case nodeFunctionObject:
 		rt := o.runtime
+		// Arrow functions do not bind their own `this`; they use the value
+		// captured lexically when the function literal was evaluated.
+		if fn.node.isArrow {
+			this = fn.this
+		}
 		stash := rt.enterFunctionScope(fn.stash, this)
 		rt.scope.frame = frame{
 			callee: fn.node.name,

--- a/type_function.go
+++ b/type_function.go
@@ -114,16 +114,10 @@ func (fn bindFunctionObject) construct(argumentList []Value) Value {
 
 // nodeFunctionObject.
 type nodeFunctionObject struct {
-	node  *nodeFunctionLiteral
-	stash stasher
-	// this holds the lexically captured `this` for arrow functions. It is
-	// only meaningful when node.isArrow is true.
-	this Value
-	// homeObject is the object a class/method was defined on, used to resolve
-	// `super` references. It is nil for ordinary functions.
-	homeObject *object
-	// defaultDerivedCtor marks a synthesised default constructor of a derived
-	// class, which forwards its arguments to the super constructor.
+	stash              stasher
+	node               *nodeFunctionLiteral
+	homeObject         *object
+	this               Value
 	defaultDerivedCtor bool
 }
 


### PR DESCRIPTION
Adds support for the commonly-used ES6 (ES2015) syntax so that "normal modern JS" mostly runs, implemented feature-by-feature (one commit each) through the full lexer → parser → AST → compiler → evaluator pipeline. The full test suite stays green throughout, with a new test file per feature.

## Features

| Feature | Highlights |
|---|---|
| Arrow functions | lexical `this`, concise & block bodies, lexical `arguments` |
| Template literals | `${}`, nesting, escapes (`\u{…}`), multi-line |
| Object shorthand / methods / computed keys | `{x}`, `{m(){}}`, `{[k]:v}` |
| `let` / `const` | full block scoping, **per-iteration loop bindings**, const immutability |
| Default parameters | `f(a, b = a + 1)` |
| Rest parameters | `f(...args)` → real array |
| Spread | `f(...arr)`, `[...a, ...b]`, strings & array-likes |
| `for...of` | arrays/strings, per-iteration `let` bindings |
| Destructuring | array/object, defaults, rest, nesting, assignment, for-of |
| Classes | constructor, methods, static, get/set, `extends`, `super()` / `super.m()` |
| Tagged templates | `` tag`a${b}` ``, `strings.raw`, method-tag `this`, plus `String.raw` |
| Destructuring in params | `f({a, b})`, `([x, ...r]) => …`, `({n = 1} = {}) => …` |

A combined snippet exercising classes + `extends`/`super` + default params + arrows + destructuring + `for...of` + template literals + `const`/`let` together works end-to-end.

## Implementation notes

- `let`/`const`/`class`/`extends`/`super` are now real keywords (regenerated via `tools/gen-tokens`); `...` (ELLIPSIS) added for rest/spread.
- `let`/`const` get genuine per-block lexical environments and per-iteration `for (let i …)` bindings, so the classic loop-closure case captures distinct values.
- Classes desugar at runtime to a constructor + prototype; `extends` wires the prototype and static chains; `super` resolves via each method's home object.
- Destructuring reuses one recursive `bindPattern` across declarations, assignment, for-of and parameters.

## Deliberate scope / known gaps

These are honest simplifications, not oversights:

- **No temporal dead zone** — reading a lexical binding before its declaration resolves to an outer scope rather than throwing.
- `let` is treated as a **hard keyword**, so it can no longer be a sloppy-mode identifier.
- **Arrow rest params** (`(...args) => …`) are not supported (needs a true cover-grammar parse; regular functions support rest fine).
- `{a = 1}` is now *accepted* as an object literal (CoverInitializedName leniency) rather than a SyntaxError — minor over-acceptance enabling the arrow cover grammar.
- Out of scope: full iterator protocol (`Symbol.iterator`), generators, `Promise`, `Proxy`, `Map`/`Set`, modules, `Symbol`, and class fields/private members (ES2022).

## Testing

- A new `*_test.go` file per feature (~190 assertions) in the repo's existing `tt`/`terst` style, plus the existing ~541 test functions — all green, no regressions.
- A few pre-existing assertions were updated where they encoded pre-ES6 behaviour (`let`/`const`/`class`/`super` as reserved words; `a..` lexing).
- These prove the features work for normal usage; they are **not** a conformance suite. There is no test262 here — that's being wired up separately to measure true spec-conformance (and is the kind of independent, parallelisable work where it pays off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)