### PR TITLE
ci: make go generate validation reproducible

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Validate go mod / generate
         run: |
           go mod tidy
-          go install golang.org/x/tools/cmd/stringer@latest
+          # Pin stringer: @latest pulls an x/tools that requires a newer Go,
+          # forcing a toolchain switch and reformatting the generated files.
+          go install golang.org/x/tools/cmd/stringer@v0.29.0
           go generate ./...
           git --no-pager diff && [[ 0 -eq $(git status --porcelain | wc -l) ]]
 

--- a/underscore/generate.go
+++ b/underscore/generate.go
@@ -1,4 +1,6 @@
 package underscore
 
-//go:generate go run download.go --url https://underscorejs.org/underscore-min.js --output underscore-min.js
-//go:generate go run download.go --url https://raw.githubusercontent.com/jashkenas/underscore/master/LICENSE --output LICENSE.underscorejs
+// Pin the Underscore version so `go generate` is reproducible; an unpinned
+// "latest" URL drifts whenever upstream publishes a new release.
+//go:generate go run download.go --url https://cdn.jsdelivr.net/npm/underscore@1.13.7/underscore-min.js --output underscore-min.js
+//go:generate go run download.go --url https://raw.githubusercontent.com/jashkenas/underscore/1.13.7/LICENSE --output LICENSE.underscorejs


### PR DESCRIPTION
## Problem

The **Validate go mod / generate** CI step fails on a clean checkout because `go generate ./...` is non-deterministic in two ways:

1. **`stringer@latest`** — `go install golang.org/x/tools/cmd/stringer@latest` now resolves to an x/tools release that requires **Go ≥ 1.25**, above the CI matrix (1.22 / 1.23). With `GOTOOLCHAIN=auto` this force-downloads `go1.25.x`, and the newer `stringer` reformats `value_kind.gen.go` — so the step's clean-tree assertion fails.
2. **Unversioned underscore fixture** — `underscore/generate.go` fetched `https://underscorejs.org/underscore-min.js` (always *latest*), so the vendored fixture drifted whenever upstream published a release (e.g. 1.13.7 → 1.13.8), again failing the clean-tree check.

This surfaces as a confusing `switching to go1.25.10` line during `go mod tidy` / `go generate` and a dirty working tree.

## Fix

- Pin `stringer` to **x/tools v0.29.0** (requires go 1.22, so no toolchain switch on either runner). Verified it reproduces the committed `value_kind.gen.go` **byte-for-byte**.
- Pin the underscore download URLs to the **1.13.7** tag (jsdelivr for the script, the git tag for the LICENSE). Verified both reproduce the committed files byte-for-byte.

No generated files needed re-committing — the pins reproduce exactly what's already in the tree.

## Verification

Ran the CI sequence locally:

```
go install golang.org/x/tools/cmd/stringer@v0.29.0
go mod tidy && go generate ./...
git status --porcelain   # clean (only this PR's 2 edits)
```

No drift in `value_kind.gen.go`, `inline.go`, `token_const.go`, or `underscore-min.js`.

> Note: this is independent of the ES6 features PR. For that branch's CI to also go green it will need this change merged in (the `pull_request` workflow runs from the PR branch's copy of the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)