### PR TITLE
fix: accept destructuring patterns as for-of/for-in targets

### DIFF
--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -357,7 +357,7 @@ func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Valu
 
 	// A block-scoped loop variable (for (let k in obj)) gets a fresh binding
 	// per iteration in its own lexical environment.
-	lexical := node.lexicalBinding != ""
+	lexical := node.lexical
 	var outerLexical stasher
 	if lexical {
 		outerLexical = rt.scope.lexical
@@ -370,18 +370,9 @@ func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Valu
 		enumerateValue := emptyValue
 		obj.enumerate(false, func(name string) bool {
 			if lexical {
-				iterEnv := rt.newDeclarationStash(outerLexical)
-				iterEnv.createBinding(node.lexicalBinding, false, Value{})
-				rt.scope.lexical = iterEnv
+				rt.scope.lexical = rt.newDeclarationStash(outerLexical)
 			}
-			into := rt.cmplEvaluateNodeExpression(into)
-			// In the case of: for (var abc in def) ...
-			if into.reference() == nil {
-				identifier := into.string()
-				// TODO Should be true or false (strictness) depending on context
-				into = toValue(getIdentifierReference(rt, rt.scope.lexical, identifier, false, -1))
-			}
-			rt.putValue(into.reference(), stringValue(name))
+			rt.bindForTarget(into, stringValue(name), lexical, node.immutable)
 			for _, node := range body {
 				value := rt.cmplEvaluateNodeStatement(node)
 				switch value.kind {
@@ -435,6 +426,14 @@ func (rt *runtime) bindForTarget(into nodeExpression, value Value, lexical, immu
 		}
 		ref := getIdentifierReference(rt, rt.scope.lexical, ve.name, false, at(ve.idx))
 		rt.putValue(ref, value)
+		return
+	}
+
+	// An assignment destructuring pattern, e.g. for ([a, b] of x) or
+	// for ({a} in obj). These bind against existing references.
+	switch into.(type) {
+	case *nodeArrayPattern, *nodeObjectPattern:
+		rt.bindPattern(into, value, bindAssign)
 		return
 	}
 

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -451,9 +451,6 @@ func (cmpl *compiler) parseStatement(stmt ast.Statement) nodeStatement {
 		if stmt.Lexical != 0 {
 			out.lexical = true
 			out.immutable = stmt.Lexical == token.CONST
-			if ve, ok := stmt.Into.(*ast.VariableExpression); ok {
-				out.lexicalBinding = ve.Name
-			}
 		}
 		out.body = cmpl.parseLoopBody(stmt.Body)
 		return out
@@ -814,13 +811,12 @@ type (
 	}
 
 	nodeForInStatement struct {
-		into           nodeExpression
-		source         nodeExpression
-		lexicalBinding string
-		body           []nodeStatement
-		lexical        bool
-		immutable      bool
-		of             bool
+		into      nodeExpression
+		source    nodeExpression
+		body      []nodeStatement
+		lexical   bool
+		immutable bool
+		of        bool
 	}
 
 	nodeForStatement struct {

--- a/for_of_test.go
+++ b/for_of_test.go
@@ -38,6 +38,81 @@ func TestForOf(t *testing.T) {
 	})
 }
 
+func TestForOfDestructuring(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Array pattern declared with const.
+		test(`
+            var out = [];
+            for (const [a, b] of [[1, 2], [3, 4]]) out.push(a + b);
+            out.join(",");
+        `, "3,7")
+
+		// Object pattern declared with let.
+		test(`
+            var out = [];
+            for (let {x, y} of [{x: 1, y: 2}, {x: 10, y: 20}]) out.push(x + y);
+            out.join(",");
+        `, "3,30")
+
+		// Assignment array pattern (no declaration keyword) over existing names.
+		test(`
+            var a, b, out = [];
+            for ([a, b] of [[1, 2], [3, 4]]) out.push(a * b);
+            out.join(",");
+        `, "2,12")
+
+		// Nested patterns with const.
+		test(`
+            var out = [];
+            for (const [a, [b]] of [[1, [2]], [3, [4]]]) out.push(a + b);
+            out.join(",");
+        `, "3,7")
+
+		// Default values inside the pattern.
+		test(`
+            var out = [];
+            for (const [a, b = 9] of [[1], [2, 3]]) out.push(a + b);
+            out.join(",");
+        `, "10,5")
+
+		// Each iteration of for (const [..] of) gets its own binding.
+		test(`
+            var fns = [];
+            for (const [x] of [[1], [2], [3]]) fns.push(function () { return x; });
+            [fns[0](), fns[1](), fns[2]()].join(",");
+        `, "1,2,3")
+	})
+}
+
+func TestForInDestructuring(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Object pattern declared with let, destructuring each key string.
+		test(`
+            var out = [];
+            for (let {length: n} in {ab: 1, cde: 1}) out.push(n);
+            out.sort().join(",");
+        `, "2,3")
+
+		// Assignment object pattern (no declaration keyword).
+		test(`
+            var n, out = [];
+            for ({length: n} in {ab: 1, cde: 1}) out.push(n);
+            out.sort().join(",");
+        `, "2,3")
+
+		// Assignment array pattern over an array's index keys.
+		test(`
+            var k, out = [];
+            for ([k] in ["x", "y"]) out.push(k);
+            out.sort().join(",");
+        `, "0,1")
+	})
+}
+
 func TestForOfControlFlow(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -874,6 +874,19 @@ func (p *parser) parseForOrForInStatement() ast.Statement {
 		switch left[0].(type) {
 		case *ast.Identifier, *ast.DotExpression, *ast.BracketExpression, *ast.VariableExpression:
 			// These are all acceptable
+		case *ast.ArrayPattern, *ast.ObjectPattern:
+			// A binding pattern declared with var/let/const, e.g.
+			// for (const [a, b] of x) or for (let {x} in obj).
+		case *ast.ArrayLiteral, *ast.ObjectLiteral:
+			// An assignment destructuring target, e.g. for ([a, b] of x)
+			// or for ({a} in obj). Reinterpret the literal as a pattern.
+			pattern, ok := literalToPattern(left[0])
+			if !ok {
+				p.error(idx, "Invalid left-hand side in for-in")
+				p.nextStatement()
+				return &ast.BadStatement{From: idx, To: p.idx}
+			}
+			left[0] = pattern
 		default:
 			p.error(idx, "Invalid left-hand side in for-in")
 			p.nextStatement()


### PR DESCRIPTION
## Problem
otto's parser rejected valid ES6 `for-of` / `for-in` loops whose left-hand side is a destructuring pattern, raising `Invalid left-hand side in for-in`. Examples that should work but didn't:

```js
for (const [a, b] of [[1, 2]]) { }   // declaration, array pattern
for (let {x, y} of arr) { }           // declaration, object pattern
for ([a, b] of arr) { }               // assignment-form target
for ({a} in obj) { }
```

## Root cause
Two gaps:
1. The for-in/for-of LHS validation switch in `parser/statement.go` only accepted `Identifier`/`DotExpression`/`BracketExpression`/`VariableExpression`. Assignment-form targets arrive as `*ast.ArrayLiteral`/`*ast.ObjectLiteral` and hit the `default` branch → error.
2. At runtime, bare pattern targets weren't bound, and the for-in path inlined assignment logic keyed on a single binding name, so destructuring lexical bindings weren't handled.

## Fix
- `parser/statement.go`: accept `*ast.ArrayPattern`/`*ast.ObjectPattern` directly, and reinterpret `*ast.ArrayLiteral`/`*ast.ObjectLiteral` LHS via the existing `literalToPattern` helper.
- `cmpl_evaluate_statement.go`: bind bare pattern targets through the existing `bindPattern(..., bindAssign)` path; refactor for-in evaluation to reuse `bindForTarget` and key its per-iteration lexical env off the `lexical` flag (mirroring for-of).
- `cmpl_parse.go`: drop the now-unused `lexicalBinding` field.

## Tests
Adds `TestForOfDestructuring` / `TestForInDestructuring` (array/object patterns, declaration + assignment forms, nesting, defaults, per-iteration bindings). Existing parser + otto suites pass (`go test -vet=off ./parser/... .`).

Verified against the TC39 test262 `for-of/dstr` and `for-in/dstr` suites: the `Invalid left-hand side in for-in` failure class drops to zero (residual failures are unrelated — Symbol/iterator, function-name inference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)