### PR TITLE
fix: emit accessor property descriptors instead of panicking

### DIFF
--- a/class_test.go
+++ b/class_test.go
@@ -75,6 +75,44 @@ func TestClassAccessors(t *testing.T) {
 	})
 }
 
+// TestClassAccessorDescriptor guards against a regression where
+// Object.getOwnPropertyDescriptor panicked on accessor (getter/setter)
+// properties because the descriptor was reflected as a data descriptor.
+func TestClassAccessorDescriptor(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Getter and setter together: the descriptor must expose get/set
+		// (not value/writable) and the correct enumerable/configurable flags.
+		test(`
+            class C { get x() { return 1; } set x(v) {} }
+            var d = Object.getOwnPropertyDescriptor(C.prototype, "x");
+            [
+                typeof d.get,
+                typeof d.set,
+                "value" in d,
+                "writable" in d,
+                d.enumerable,
+                d.configurable,
+            ].join(",");
+        `, "function,function,false,false,false,true")
+
+		// Getter only: set must be undefined, get must be the function.
+		test(`
+            class C { get x() { return 1; } }
+            var d = Object.getOwnPropertyDescriptor(C.prototype, "x");
+            [typeof d.get, d.set === undefined, "get" in d, "set" in d].join(",");
+        `, "function,true,true,true")
+
+		// Setter only: get must be undefined, set must be the function.
+		test(`
+            class C { set x(v) {} }
+            var d = Object.getOwnPropertyDescriptor(C.prototype, "x");
+            [d.get === undefined, typeof d.set].join(",");
+        `, "true,function")
+	})
+}
+
 func TestClassInheritance(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()

--- a/property.go
+++ b/property.go
@@ -196,21 +196,24 @@ func toPropertyDescriptor(rt *runtime, value Value) property {
 
 func (rt *runtime) fromPropertyDescriptor(descriptor property) *object {
 	obj := rt.newObject()
-	if descriptor.isDataDescriptor() {
-		obj.defineProperty("value", descriptor.value.(Value), 0o111, false)
-		obj.defineProperty("writable", boolValue(descriptor.writable()), 0o111, false)
-	} else if descriptor.isAccessorDescriptor() {
-		getSet := descriptor.value.(propertyGetSet)
+	// An accessor property's value holds a propertyGetSet rather than a Value,
+	// so it must be reflected as get/set before falling back to value/writable.
+	// Check the underlying value type directly: a property's write mode bits do
+	// not reliably distinguish an accessor from a data descriptor.
+	if getSet, isAccessor := descriptor.value.(propertyGetSet); isAccessor {
 		get := Value{}
-		if getSet[0] != nil {
+		if getSet[0] != nil && getSet[0] != &nilGetSetObject {
 			get = objectValue(getSet[0])
 		}
 		set := Value{}
-		if getSet[1] != nil {
+		if getSet[1] != nil && getSet[1] != &nilGetSetObject {
 			set = objectValue(getSet[1])
 		}
 		obj.defineProperty("get", get, 0o111, false)
 		obj.defineProperty("set", set, 0o111, false)
+	} else {
+		obj.defineProperty("value", descriptor.value.(Value), 0o111, false)
+		obj.defineProperty("writable", boolValue(descriptor.writable()), 0o111, false)
 	}
 	obj.defineProperty("enumerable", boolValue(descriptor.enumerable()), 0o111, false)
 	obj.defineProperty("configurable", boolValue(descriptor.configurable()), 0o111, false)


### PR DESCRIPTION
## Problem
`Object.getOwnPropertyDescriptor` (and related descriptor reads) **panicked** on accessor properties — e.g. class getters/setters, or a function's `caller`:

```
panic: interface conversion: interface {} is otto.propertyGetSet, not otto.Value
```

```js
class C { get x() { return 1; } set x(v) {} }
Object.getOwnPropertyDescriptor(C.prototype, "x");   // panics
```

## Root cause
`(*runtime).fromPropertyDescriptor` branched on `descriptor.isDataDescriptor()` first and, in that branch, did `descriptor.value.(Value)`. For an accessor property the `value` field holds a `propertyGetSet` (`[2]*object`), not a `Value`. Crucially `isDataDescriptor()` returns `true` for accessors too (it short-circuits on `writeSet()`, and accessor properties have write-mode bits that aren't "unspecified"), so the existing `isAccessorDescriptor()` branch was dead code and the type assertion panicked.

## Fix
Reorder `fromPropertyDescriptor` (`property.go`) to branch on the *actual underlying value type*: if `descriptor.value` is a `propertyGetSet`, emit an accessor descriptor (`get`/`set`, each the function object or `undefined`); otherwise emit a data descriptor (`value`/`writable`). Both paths still emit `enumerable`/`configurable`. The `&nilGetSetObject` sentinel surfaces as `undefined`.

## Tests
Adds `TestClassAccessorDescriptor` (get+set, getter-only, setter-only) asserting the descriptor exposes `get`/`set` (not `value`/`writable`), missing accessor is `undefined`, and `enumerable=false`/`configurable=true`. Existing otto suite passes (`go test -vet=off . ./...`).

Verified against the TC39 test262 class accessor/getter/setter suites: the panic is eliminated (residual failures are an unrelated detail — accessor functions lacking a `prototype` own-property).

🤖 Generated with [Claude Code](https://claude.com/claude-code)