### PR TITLE
feat: add ES6+ Object and Number static methods

### DIFF
--- a/builtin_number.go
+++ b/builtin_number.go
@@ -98,6 +98,46 @@ func builtinNumberIsNaN(call FunctionCall) Value {
 	return boolValue(call.Argument(0).IsNaN())
 }
 
+func builtinNumberIsInteger(call FunctionCall) Value {
+	// No coercion: non-Number arguments are always false.
+	value := call.Argument(0)
+	if value.kind != valueNumber {
+		return boolValue(false)
+	}
+	num := value.float64()
+	if math.IsNaN(num) || math.IsInf(num, 0) {
+		return boolValue(false)
+	}
+	return boolValue(math.Trunc(num) == num)
+}
+
+func builtinNumberIsFinite(call FunctionCall) Value {
+	// No coercion (unlike the global isFinite): non-Number arguments are false.
+	value := call.Argument(0)
+	if value.kind != valueNumber {
+		return boolValue(false)
+	}
+	num := value.float64()
+	return boolValue(!math.IsNaN(num) && !math.IsInf(num, 0))
+}
+
+func builtinNumberIsSafeInteger(call FunctionCall) Value {
+	// isInteger AND abs(value) <= 2^53 - 1. No coercion.
+	value := call.Argument(0)
+	if value.kind != valueNumber {
+		return boolValue(false)
+	}
+	num := value.float64()
+	if math.IsNaN(num) || math.IsInf(num, 0) {
+		return boolValue(false)
+	}
+	if math.Trunc(num) != num {
+		return boolValue(false)
+	}
+	const maxSafeInteger = float64(1<<53 - 1)
+	return boolValue(math.Abs(num) <= maxSafeInteger)
+}
+
 func builtinNumberToLocaleString(call FunctionCall) Value {
 	value := call.thisClassObject(classNumberName).primitiveValue()
 	locale := call.Argument(0)

--- a/builtin_object.go
+++ b/builtin_object.go
@@ -318,6 +318,93 @@ func builtinObjectValues(call FunctionCall) Value {
 	panic(call.runtime.panicTypeError("Object.Values is nil"))
 }
 
+func builtinObjectEntries(call FunctionCall) Value {
+	if obj, entries := call.Argument(0).object(), []Value(nil); nil != obj {
+		// Own enumerable string-keyed properties, in the same order as
+		// Object.keys/Object.values.
+		obj.enumerate(false, func(name string) bool {
+			entry := call.runtime.newArrayOf([]Value{stringValue(name), obj.get(name)})
+			entries = append(entries, objectValue(entry))
+			return true
+		})
+		return objectValue(call.runtime.newArrayOf(entries))
+	}
+	panic(call.runtime.panicTypeError("Object.Entries is nil"))
+}
+
+func builtinObjectIs(call FunctionCall) Value {
+	// SameValue(x, y) - like === except NaN === NaN and +0 !== -0.
+	return boolValue(sameValue(call.Argument(0), call.Argument(1)))
+}
+
+func builtinObjectFromEntries(call FunctionCall) Value {
+	// NOTE: A fully spec-compliant implementation iterates the argument via its
+	// Symbol.iterator. otto does not implement Symbol.iterator, so we accept any
+	// array-like list of [key, value] pairs, which covers the common case
+	// (e.g. arrays and Map-like array-of-entries). General iterables are not
+	// supported.
+	iterable := call.Argument(0)
+	if !iterable.IsObject() {
+		panic(call.runtime.panicTypeError("Object.fromEntries requires an array-like argument"))
+	}
+	source := iterable.object()
+	length := objectLength(source)
+
+	result := call.runtime.newObject()
+	for index := uint32(0); index < length; index++ {
+		entryValue := source.get(strconv.FormatUint(uint64(index), 10))
+		if !entryValue.IsObject() {
+			panic(call.runtime.panicTypeError("Object.fromEntries entry is not an object"))
+		}
+		entry := entryValue.object()
+		key := entry.get("0").string()
+		value := entry.get("1")
+		result.put(key, value, true)
+	}
+
+	return objectValue(result)
+}
+
+func builtinObjectSetPrototypeOf(call FunctionCall) Value {
+	val := call.Argument(0)
+	switch val.kind {
+	case valueUndefined, valueNull:
+		panic(call.runtime.panicTypeError("Object.setPrototypeOf called on null or undefined"))
+	}
+
+	proto := call.Argument(1)
+	if !proto.IsObject() && !proto.IsNull() {
+		panic(call.runtime.panicTypeError("Object.setPrototypeOf: prototype must be an object or null"))
+	}
+
+	// For non-object values (primitives) the prototype cannot change, but per
+	// spec the value is returned unchanged.
+	obj := val.object()
+	if obj != nil {
+		obj.prototype = proto.object()
+	}
+
+	return val
+}
+
+func builtinObjectGetOwnPropertyDescriptors(call FunctionCall) Value {
+	val := call.Argument(0)
+	obj := val.object()
+	if obj == nil {
+		panic(call.runtime.panicTypeError("Object.GetOwnPropertyDescriptors is nil"))
+	}
+
+	result := call.runtime.newObject()
+	obj.enumerate(true, func(name string) bool {
+		if descriptor := obj.getOwnProperty(name); descriptor != nil {
+			result.put(name, objectValue(call.runtime.fromPropertyDescriptor(*descriptor)), true)
+		}
+		return true
+	})
+
+	return objectValue(result)
+}
+
 func builtinObjectGetOwnPropertyNames(call FunctionCall) Value {
 	if obj, propertyNames := call.Argument(0).object(), []Value(nil); nil != obj {
 		obj.enumerate(true, func(name string) bool {

--- a/builtin_object.go
+++ b/builtin_object.go
@@ -351,7 +351,7 @@ func builtinObjectFromEntries(call FunctionCall) Value {
 	length := objectLength(source)
 
 	result := call.runtime.newObject()
-	for index := uint32(0); index < length; index++ {
+	for index := range length {
 		entryValue := source.get(strconv.FormatUint(uint64(index), 10))
 		if !entryValue.IsObject() {
 			panic(call.runtime.panicTypeError("Object.fromEntries entry is not an object"))

--- a/inline.go
+++ b/inline.go
@@ -1013,6 +1013,191 @@ func (rt *runtime) newContext() {
 					},
 				},
 			},
+			"entries": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "entries",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "entries",
+							call: builtinObjectEntries,
+						},
+					},
+				},
+			},
+			"is": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "is",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "is",
+							call: builtinObjectIs,
+						},
+					},
+				},
+			},
+			"fromEntries": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "fromEntries",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "fromEntries",
+							call: builtinObjectFromEntries,
+						},
+					},
+				},
+			},
+			"setPrototypeOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "setPrototypeOf",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "setPrototypeOf",
+							call: builtinObjectSetPrototypeOf,
+						},
+					},
+				},
+			},
+			"getOwnPropertyDescriptors": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "getOwnPropertyDescriptors",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "getOwnPropertyDescriptors",
+							call: builtinObjectGetOwnPropertyDescriptors,
+						},
+					},
+				},
+			},
 		},
 		propertyOrder: []string{
 			propertyLength,
@@ -1032,6 +1217,11 @@ func (rt *runtime) newContext() {
 			"keys",
 			"values",
 			"getOwnPropertyNames",
+			"entries",
+			"is",
+			"fromEntries",
+			"setPrototypeOf",
+			"getOwnPropertyDescriptors",
 		},
 	}
 
@@ -3522,6 +3712,191 @@ func (rt *runtime) newContext() {
 					},
 				},
 			},
+			"isInteger": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "isInteger",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "isInteger",
+							call: builtinNumberIsInteger,
+						},
+					},
+				},
+			},
+			"isFinite": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "isFinite",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "isFinite",
+							call: builtinNumberIsFinite,
+						},
+					},
+				},
+			},
+			"isSafeInteger": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "isSafeInteger",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "isSafeInteger",
+							call: builtinNumberIsSafeInteger,
+						},
+					},
+				},
+			},
+			"parseInt": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "parseInt",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "parseInt",
+							call: builtinGlobalParseInt,
+						},
+					},
+				},
+			},
+			"parseFloat": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "parseFloat",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "parseFloat",
+							call: builtinGlobalParseFloat,
+						},
+					},
+				},
+			},
 			"MAX_VALUE": {
 				mode: 0,
 				value: Value{
@@ -3562,6 +3937,11 @@ func (rt *runtime) newContext() {
 			propertyLength,
 			propertyPrototype,
 			"isNaN",
+			"isInteger",
+			"isFinite",
+			"isSafeInteger",
+			"parseInt",
+			"parseFloat",
 			"MAX_VALUE",
 			"MIN_VALUE",
 			"NaN",

--- a/object_number_statics_test.go
+++ b/object_number_statics_test.go
@@ -1,0 +1,222 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestObjectEntries(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// [key, value] pairs in Object.keys order.
+		test(`
+            var o = { a: 1, b: 2, c: 3 };
+            JSON.stringify(Object.entries(o));
+        `, `[["a",1],["b",2],["c",3]]`)
+
+		// Only own enumerable string-keyed properties (not inherited).
+		test(`
+            var proto = { inherited: 99 };
+            var o = Object.create(proto);
+            o.own = 1;
+            JSON.stringify(Object.entries(o));
+        `, `[["own",1]]`)
+
+		// Non-enumerable own properties are excluded.
+		test(`
+            var o = {};
+            Object.defineProperty(o, "hidden", { value: 1, enumerable: false });
+            o.shown = 2;
+            JSON.stringify(Object.entries(o));
+        `, `[["shown",2]]`)
+
+		test(`Object.entries.length`, 1)
+	})
+}
+
+func TestObjectIs(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// NaN is the same as NaN under SameValue (unlike ===).
+		test(`Object.is(NaN, NaN)`, true)
+		test(`NaN === NaN`, false)
+
+		// +0 and -0 differ under SameValue (unlike ===).
+		test(`Object.is(0, -0)`, false)
+		test(`Object.is(-0, -0)`, true)
+		test(`0 === -0`, true)
+
+		test(`Object.is(1, 1)`, true)
+		test(`Object.is("foo", "foo")`, true)
+		test(`Object.is("foo", "bar")`, false)
+		test(`Object.is(null, null)`, true)
+		test(`Object.is(undefined, undefined)`, true)
+
+		test(`var o = {}; Object.is(o, o)`, true)
+		test(`Object.is({}, {})`, false)
+
+		test(`Object.is.length`, 2)
+	})
+}
+
+func TestObjectFromEntries(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var o = Object.fromEntries([['a', 1], ['b', 2]]);
+            [o.a, o.b].join(",");
+        `, "1,2")
+
+		// Later duplicate keys win.
+		test(`
+            var o = Object.fromEntries([['x', 1], ['x', 9]]);
+            o.x;
+        `, 9)
+
+		// Round-trips with Object.entries.
+		test(`
+            var src = { a: 1, b: 2 };
+            JSON.stringify(Object.fromEntries(Object.entries(src)));
+        `, `{"a":1,"b":2}`)
+
+		test(`Object.fromEntries.length`, 1)
+	})
+}
+
+func TestObjectSetPrototypeOf(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Changing the prototype changes inheritance.
+		test(`
+            var proto = { greet: function() { return "hi"; } };
+            var o = {};
+            var result = Object.setPrototypeOf(o, proto);
+            [o.greet(), result === o].join(",");
+        `, "hi,true")
+
+		// Setting prototype to null removes inheritance.
+		test(`
+            var o = { foo: 1 };
+            Object.setPrototypeOf(o, null);
+            Object.getPrototypeOf(o);
+        `, "null")
+
+		test(`Object.setPrototypeOf.length`, 2)
+	})
+}
+
+func TestObjectGetOwnPropertyDescriptors(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            var o = { a: 1 };
+            var d = Object.getOwnPropertyDescriptors(o);
+            [ d.a.value, d.a.writable, d.a.enumerable, d.a.configurable ].join(",");
+        `, "1,true,true,true")
+
+		// Non-enumerable own properties are still included.
+		test(`
+            var o = {};
+            Object.defineProperty(o, "hidden", { value: 7, enumerable: false });
+            var d = Object.getOwnPropertyDescriptors(o);
+            [ d.hidden.value, d.hidden.enumerable ].join(",");
+        `, "7,false")
+
+		test(`Object.getOwnPropertyDescriptors.length`, 1)
+	})
+}
+
+func TestNumberIsInteger(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`Number.isInteger(5)`, true)
+		test(`Number.isInteger(5.0)`, true)
+		test(`Number.isInteger(-100)`, true)
+		test(`Number.isInteger(5.5)`, false)
+		test(`Number.isInteger(NaN)`, false)
+		test(`Number.isInteger(Infinity)`, false)
+		test(`Number.isInteger(-Infinity)`, false)
+
+		// No coercion: non-numbers are always false.
+		test(`Number.isInteger("5")`, false)
+		test(`Number.isInteger(true)`, false)
+		test(`Number.isInteger(null)`, false)
+		test(`Number.isInteger(undefined)`, false)
+		test(`Number.isInteger()`, false)
+
+		test(`Number.isInteger.length`, 1)
+	})
+}
+
+func TestNumberIsFinite(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`Number.isFinite(5)`, true)
+		test(`Number.isFinite(0)`, true)
+		test(`Number.isFinite(NaN)`, false)
+		test(`Number.isFinite(Infinity)`, false)
+		test(`Number.isFinite(-Infinity)`, false)
+
+		// No coercion (unlike global isFinite).
+		test(`Number.isFinite("5")`, false)
+		test(`isFinite("5")`, true)
+		test(`Number.isFinite(null)`, false)
+		test(`isFinite(null)`, true)
+		test(`Number.isFinite(undefined)`, false)
+		test(`Number.isFinite()`, false)
+
+		test(`Number.isFinite.length`, 1)
+	})
+}
+
+func TestNumberIsSafeInteger(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`Number.isSafeInteger(5)`, true)
+		test(`Number.isSafeInteger(Math.pow(2, 53) - 1)`, true)
+		test(`Number.isSafeInteger(Math.pow(2, 53))`, false)
+		test(`Number.isSafeInteger(-(Math.pow(2, 53) - 1))`, true)
+		test(`Number.isSafeInteger(5.5)`, false)
+		test(`Number.isSafeInteger(NaN)`, false)
+		test(`Number.isSafeInteger(Infinity)`, false)
+
+		// No coercion.
+		test(`Number.isSafeInteger("5")`, false)
+		test(`Number.isSafeInteger(null)`, false)
+		test(`Number.isSafeInteger()`, false)
+
+		test(`Number.isSafeInteger.length`, 1)
+	})
+}
+
+func TestNumberParseIntFloat(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// Behavioural parity with the global parseInt/parseFloat. They share the
+		// same underlying builtin but are distinct function objects, so identity
+		// (===) does not hold.
+		test(`Number.parseInt("42") === parseInt("42")`, true)
+		test(`Number.parseFloat("3.14") === parseFloat("3.14")`, true)
+
+		test(`Number.parseInt("42")`, 42)
+		test(`Number.parseInt("0xff", 16)`, 255)
+		test(`Number.parseInt("10", 2)`, 2)
+		test(`Number.parseInt("  -7  ")`, -7)
+		test(`isNaN(Number.parseInt("xyz"))`, true)
+
+		test(`Number.parseFloat("3.14")`, 3.14)
+		test(`Number.parseFloat("  2.5e3")`, 2500)
+		test(`isNaN(Number.parseFloat("abc"))`, true)
+
+		test(`Number.parseInt.length`, 2)
+		test(`Number.parseFloat.length`, 1)
+	})
+}

--- a/tools/gen-jscore/.gen-jscore.yaml
+++ b/tools/gen-jscore/.gen-jscore.yaml
@@ -38,6 +38,16 @@ types:
         function: 1
       - name: getOwnPropertyNames
         function: 1
+      - name: entries
+        function: 1
+      - name: is
+        function: 2
+      - name: fromEntries
+        function: 1
+      - name: setPrototypeOf
+        function: 2
+      - name: getOwnPropertyDescriptors
+        function: 1
     prototype:
       value: prototypeValueObject
       properties:
@@ -242,6 +252,18 @@ types:
         value: rt.global.NumberPrototype
       - name: isNaN
         function: 1
+      - name: isInteger
+        function: 1
+      - name: isFinite
+        function: 1
+      - name: isSafeInteger
+        function: 1
+      - name: parseInt
+        function: 2
+        call: GlobalParseInt
+      - name: parseFloat
+        function: 1
+        call: GlobalParseFloat
       - name: MAX_VALUE
         value: math.MaxFloat64
         kind: valueNumber


### PR DESCRIPTION
Adds the missing static methods on `Object` and `Number`:

**Object:** `entries`, `is`, `fromEntries`, `setPrototypeOf`, `getOwnPropertyDescriptors`
**Number:** `isInteger`, `isFinite`, `isSafeInteger`, `parseInt`, `parseFloat`

Spec notes:
- `Object.entries` reuses the `Object.keys` enumeration (own enumerable string-keyed, same order).
- `Object.is` delegates to otto's existing `sameValue` (so `Object.is(NaN,NaN)` is `true`, `Object.is(+0,-0)` is `false`).
- `Object.fromEntries` takes an **array-like** of `[k,v]` pairs (otto has no `Symbol.iterator`; general-iterable support is noted as a limitation in a comment).
- `Object.getOwnPropertyDescriptors` reuses the same `fromPropertyDescriptor` path as `getOwnPropertyDescriptor`.
- `Number.isInteger/isFinite/isSafeInteger` do **no coercion** (non-Number → `false`).
- `Number.parseInt/parseFloat` point at the same underlying builtins as the globals (via the gen-jscore `call:` override) — identical behaviour, no wrapper.

### How
Native builtins in `builtin_object.go` / `builtin_number.go`, declared in `tools/gen-jscore/.gen-jscore.yaml`, `inline.go` regenerated. Tests in `object_number_statics_test.go`.

`go build ./...` + `go test -vet=off ./...` pass; codegen regen is idempotent.

> Note: sibling method PRs also touch generated `inline.go` and the shared `.gen-jscore.yaml`; after the first merges, resolve any conflict by keeping both sides' YAML additions and re-running `go run ./tools/gen-jscore -output inline.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)