### PR TITLE
fix: spread in new expressions and labelled break/continue in for-of

### DIFF
--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -374,10 +374,7 @@ func (rt *runtime) cmplEvaluateNodeDotExpression(node *nodeDotExpression) Value 
 func (rt *runtime) cmplEvaluateNodeNewExpression(node *nodeNewExpression) Value {
 	callee := rt.cmplEvaluateNodeExpression(node.callee)
 
-	argumentList := []Value{}
-	for _, argumentNode := range node.argumentList {
-		argumentList = append(argumentList, rt.cmplEvaluateNodeExpression(argumentNode).resolve())
-	}
+	argumentList := rt.evaluateArgumentList(node.argumentList)
 
 	var name string
 	if rf := callee.reference(); rf != nil {

--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -335,12 +335,15 @@ func (rt *runtime) declareLexicalBinding(name string, value Value, immutable boo
 }
 
 func (rt *runtime) cmplEvaluateNodeForInStatement(node *nodeForInStatement) Value {
-	labels := append(rt.labels, "") //nolint:gocritic
-	rt.labels = nil
-
+	// Delegate before consuming rt.labels: cmplEvaluateNodeForOfStatement
+	// builds its own label set, and clearing the stack here would lose any
+	// labels attached to the loop.
 	if node.of {
 		return rt.cmplEvaluateNodeForOfStatement(node)
 	}
+
+	labels := append(rt.labels, "") //nolint:gocritic
+	rt.labels = nil
 
 	source := rt.cmplEvaluateNodeExpression(node.source)
 	sourceValue := source.resolve()

--- a/for_of_test.go
+++ b/for_of_test.go
@@ -129,6 +129,51 @@ func TestForOfControlFlow(t *testing.T) {
 	})
 }
 
+func TestForOfLabelledControlFlow(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		// continue targeting a label on a for-of loop.
+		test(`
+            var out = [];
+            outer: for (var a of [1, 2]) {
+                for (var b of [10, 20]) {
+                    if (b === 20) continue outer;
+                    out.push(a + ":" + b);
+                }
+                out.push("unreachable");
+            }
+            out.push("after");
+            out.join(",");
+        `, "1:10,2:10,after")
+
+		// break targeting a label on a for-of loop.
+		test(`
+            var out = [];
+            outer: for (var a of [1, 2]) {
+                for (var b of [10, 20]) {
+                    out.push(a + ":" + b);
+                    if (a === 1 && b === 10) break outer;
+                }
+            }
+            out.push("after");
+            out.join(",");
+        `, "1:10,after")
+
+		// A labelled for-of nested inside another for-of.
+		test(`
+            var out = [];
+            for (var a of [1, 2]) {
+                inner: for (var b of [10, 20]) {
+                    if (b === 10) continue inner;
+                    out.push(a + ":" + b);
+                }
+            }
+            out.join(",");
+        `, "1:20,2:20")
+	})
+}
+
 func TestForOfPerIteration(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()

--- a/spread_test.go
+++ b/spread_test.go
@@ -54,3 +54,33 @@ func TestSpreadArrayLiteral(t *testing.T) {
         `, "x,y")
 	})
 }
+
+func TestSpreadNewExpression(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            function Point(x, y) { this.x = x; this.y = y; }
+            var p = new Point(...[1, 2]);
+            p.x + "," + p.y;
+        `, "1,2")
+
+		// Spread mixed with fixed arguments.
+		test(`
+            function T(a, b, c) { this.s = [a, b, c].join(","); }
+            new T(1, ...[2, 3]).s;
+        `, "1,2,3")
+
+		// Spread into a built-in constructor.
+		test(`new Array(...[1, 2, 3]).join(",");`, "1,2,3")
+
+		// Spreading a non-iterable into new throws a TypeError.
+		test(`
+            try {
+                new Date(...5);
+            } catch (e) {
+                e instanceof TypeError;
+            }
+        `, true)
+	})
+}


### PR DESCRIPTION
Fixes the two show-stopping bugs found while reviewing the ES6 work for production readiness.

## 1. `new Foo(...args)` panicked the Go runtime

```js
new Date(...[2020, 1, 1])
// panic: unknown node type: *otto.nodeSpreadExpression
```

`cmplEvaluateNodeNewExpression` evaluated its argument list with a hand-rolled loop that didn't know about spread nodes, so any spread argument hit the unknown-node panic and crashed the embedding process. Regular calls and `super(...)` already expand spreads via `evaluateArgumentList` — `new` now uses it too. As a bonus, spreading a non-iterable into `new` now throws the proper `TypeError` instead of panicking.

## 2. Labelled `break`/`continue` targeting a for-of loop silently killed the program

```js
outer: for (const a of [1, 2]) {
  for (const b of [1, 2]) { if (b === 2) continue outer; }
}
console.log("never printed");  // exited 0, silently
```

`cmplEvaluateNodeForInStatement` consumed the pending label stack (`rt.labels`) **before** checking `node.of` and delegating, so the for-of evaluator rebuilt its label set from nil and never matched the target label. The unhandled completion escaped the loop and aborted the rest of the program with no error — exit 0, statements after the loop never ran. The delegation now happens before the labels are consumed. Classic `for` and `for-in` were unaffected.

## Testing

- Regression tests added for both: `TestSpreadNewExpression` (spread-only, mixed fixed+spread, built-in constructor, non-iterable TypeError) and `TestForOfLabelledControlFlow` (labelled continue, labelled break, labelled inner for-of).
- `go test -vet=off ./...` green.
- Verified the original panic and silent-termination repros against the rebuilt `./otto` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)